### PR TITLE
Truncate CMAC based on desired mac length

### DIFF
--- a/backends/backend_openssl.c
+++ b/backends/backend_openssl.c
@@ -1779,6 +1779,14 @@ static int openssl_cmac_generate(struct hmac_data *data)
 
 	logger_binary(LOGGER_DEBUG, data->mac.buf, data->mac.len, "mac");
 
+	// Truncate to desired macLen, which is in bits
+	if (data->mac.len > data->maclen / 8) {
+		data->mac.buf[data->maclen / 8] = '\0';
+		data->mac.len = data->maclen / 8;
+		logger(LOGGER_DEBUG, "Truncated mac to maclen: %d\n", data->maclen);
+		logger_binary(LOGGER_DEBUG, data->mac.buf, data->mac.len, "mac");
+	}
+
 	ret = 0;
 
 out:


### PR DESCRIPTION
While using this great tool for ACVT (thanks!!), I came across this edge case that the AES CMAC is to be truncated based on [macLen](https://pages.nist.gov/ACVP/draft-fussell-acvp-mac.html#mac_caps_table). 

I've attached a small test response/request file with answers accepted by ACVT.
[cmacAesExample.zip](https://github.com/smuellerDD/acvpparser/files/6039185/cmacAesExample.zip)