### PR TITLE
Disable KTS-IFC for regression testing

### DIFF
--- a/helper/exec_lib.sh
+++ b/helper/exec_lib.sh
@@ -147,7 +147,8 @@ REGRESSION_VECTOR_SKIP="
 	algorithm:KAS-FFC
 	algorithm:KAS-ECC
 	ivGen:internal
-	algorithm:KDF"
+	algorithm:KDF
+	algorithm:KTS-IFC"
 
 #
 # Execute testing


### PR DESCRIPTION
IFC cannot be compared as OAEP always generates a new random number.