### PR TITLE
Add functionalities to the parser

### DIFF
--- a/backends/backend_openssl_common.c
+++ b/backends/backend_openssl_common.c
@@ -707,6 +707,7 @@ static int openssl_mct_update(struct sym_data *data, flags_t parsed_flags)
 	EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX *) data->priv;
 	size_t origlen = data->data.len;
 	int outl;
+	int ret = 0;
 
 	logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len,
 		      (parsed_flags & FLAG_OP_ENC) ?
@@ -724,17 +725,49 @@ static int openssl_mct_update(struct sym_data *data, flags_t parsed_flags)
 		origlen = data->data.len;
 		data->data.len = data->data_len_bits;
 	}
+	if (data->cipher == ACVP_XTS) {
+		BIGNUM *tweak = NULL;
+		int pos = 0;
+		int len = data->data.len;
+		int dataUnitBytes = data->xts_data_unit_len >> 3;
 
-	if (!EVP_CipherUpdate(ctx, data->data.buf, &outl, data->data.buf,
-			      (int)data->data.len)) {
-		logger(LOGGER_WARN, "Update failed\n");
-		return -EFAULT;
-	}
+		tweak = BN_bin2bn(data->iv.buf, data->iv.len, NULL);
+		CKNULL(tweak, -ENOMEM);
+		while (len > 0) {
+			int d_len = (len > dataUnitBytes)? dataUnitBytes : len;
 
-	if (!EVP_CipherFinal_ex(ctx, data->data.buf, &outl)) {
-		logger(LOGGER_WARN, "Final failed: %s\n",
-		       ERR_error_string(ERR_get_error(), NULL));
-		return -EFAULT;
+			if (!EVP_CipherUpdate(ctx, data->data.buf + pos, &outl, data->data.buf + pos, d_len)) {
+				logger(LOGGER_WARN, "Update failed\n");
+				return -EFAULT;
+			}
+
+			pos += outl;
+			len -= outl;
+			if (!EVP_CipherFinal_ex(ctx, data->data.buf + pos, &outl)) {
+				logger(LOGGER_WARN, "Final failed: %s\n",
+					ERR_error_string(ERR_get_error(), NULL));
+				return -EFAULT;
+			}
+
+			if (!BN_add_word(tweak, 1)) {
+				logger(LOGGER_WARN, "BN_add_word() failed");
+				return -EFAULT;
+			}
+			BN_bn2bin(tweak, ctx->iv + data->iv.len - BN_num_bytes(tweak));
+		}
+		BN_free(tweak);
+	} else {
+		if (!EVP_CipherUpdate(ctx, data->data.buf, &outl, data->data.buf,
+					(int)data->data.len)) {
+			logger(LOGGER_WARN, "Update failed\n");
+			return -EFAULT;
+		}
+
+		if (!EVP_CipherFinal_ex(ctx, data->data.buf, &outl)) {
+			logger(LOGGER_WARN, "Final failed: %s\n",
+				ERR_error_string(ERR_get_error(), NULL));
+			return -EFAULT;
+		}
 	}
 
 	if (data->data.len != origlen)
@@ -744,7 +777,8 @@ static int openssl_mct_update(struct sym_data *data, flags_t parsed_flags)
 		      (parsed_flags & FLAG_OP_ENC) ?
 		      "ciphertext" : "plaintext");
 
-	return 0;
+out:
+	return ret;
 }
 
 /*

--- a/parser/parser_kdf_component.c
+++ b/parser/parser_kdf_component.c
@@ -278,6 +278,7 @@ static int kdf_tester_ikev2(struct json_object *in, struct json_object *out,
 	const struct json_entry kdf_ikev2_testgroup_entries[] = {
 		{"hashAlg",			{.data.largeint = &kdf_ikev2_vector.hashalg, PARSER_CIPHER},	FLAG_OP_KDF_TYPE_IKEV2 | FLAG_OP_AFT},
 		{"derivedKeyingMaterialLength",	{.data.integer = &kdf_ikev2_vector.dkmlen, PARSER_UINT},	FLAG_OP_KDF_TYPE_IKEV2 | FLAG_OP_AFT },
+		{"dhLength",			{.data.integer = &kdf_ikev2_vector.dhlen, PARSER_UINT},		FLAG_OP_KDF_TYPE_IKEV2 | FLAG_OP_AFT },
 		{"tests",			{.data.array = &kdf_ikev2_test, PARSER_ARRAY},			FLAG_OP_KDF_TYPE_IKEV2 | FLAG_OP_AFT },
 	};
 	const struct json_array kdf_ikev2_testgroup = SET_ARRAY(kdf_ikev2_testgroup_entries, NULL);

--- a/parser/parser_kdf_ikev2.h
+++ b/parser/parser_kdf_ikev2.h
@@ -33,6 +33,7 @@ extern "C"
  *
  * @var hashalg [in] Hash algorithm to be used for PRF.
  * @var dkmlen [in] Length of derived key material to be produced
+ * @var dhlen [in] Length of Diffie Hellman shared secret
  * @var n_init [in] Value of initiator nonce (Ni in RFC 5996)
  * @var n_resp [in] Value of responder nonce (Nr in RFC 5996)
  * @var spi_init [in] Security parameter indice of the initiator
@@ -54,6 +55,7 @@ extern "C"
 struct kdf_ikev2_data {
 	uint64_t hashalg;
 	uint32_t dkmlen;
+	uint32_t dhlen;
 	struct buffer n_init;
 	struct buffer n_resp;
 	struct buffer spi_init;

--- a/parser/parser_rsa.h
+++ b/parser/parser_rsa.h
@@ -76,6 +76,7 @@ struct rsa_keygen_prime_data {
  * @var xq [out]
  * @var xq1 [out]
  * @var xq2 [out]
+ * @var bitlen_in [in]
  * @var bitlen [out]
  *
  * The following buffers are for CRT key format.
@@ -99,6 +100,7 @@ struct rsa_keygen_data {
 	struct buffer xq;
 	struct buffer xq1;
 	struct buffer xq2;
+	unsigned int bitlen_in;
 	unsigned int bitlen[4];
 
 	struct buffer dmp1;

--- a/parser/parser_sym.c
+++ b/parser/parser_sym.c
@@ -1056,6 +1056,7 @@ static int sym_aes_tester(struct json_object *in, struct json_object *out,
 		{"ct",		{.data.buf = &vector.data, PARSER_BIN},	FLAG_OP_DEC | FLAG_OP_AFT},
 
 		{"payloadLen",	{.data.integer = &vector.data_len_bits, PARSER_UINT},	FLAG_OPTIONAL | FLAG_OP_ENC | FLAG_OP_DEC | FLAG_OP_AFT},
+		{"dataUnitLen",	{.data.integer = &vector.xts_data_unit_len, PARSER_UINT},	FLAG_OPTIONAL | FLAG_OP_ENC | FLAG_OP_DEC | FLAG_OP_AFT},
 	};
 	const struct json_array sym_test_aft = SET_ARRAY(sym_test_aft_entries, &sym_testresult_aft);
 

--- a/parser/parser_sym.h
+++ b/parser/parser_sym.h
@@ -50,6 +50,7 @@ extern "C"
  * @var xts_sequence_no [in] If XTS sequence number is requested, it is
  *			       stored in this variable. In this case, the IV
  *			       is NULL.
+ * @var xts_data_unit_len [in] Length of XTS data unit in bits.
  * @var inner_loop_final_cj1[out] This value is optional and contains the final
  * 				  C[j-1] cipher text from the inner loop for
  *				  AES. If this value is set the inner loop of
@@ -81,6 +82,7 @@ struct sym_data {
 	struct buffer data;
 	uint32_t data_len_bits;
 	uint32_t xts_sequence_no;
+	uint32_t xts_data_unit_len;
 	struct buffer inner_loop_final_cj1;
 	uint32_t integrity_error;
 	struct buffer kwcipher;


### PR DESCRIPTION
This PR contains the following fixes:
- adds support for AES-XTS data unit length for ACVP-AES-XTS revision 2.0
- adds support for RSA keyGen according to FIPS 186-4 appendix B.3.6
- implements new RSA DecryptionPrimitive solving algorithm
- adds dhLength parsing for IKEv2

All changes have been used to generate response vectors validated on the ACVP production server.

Sample ACVP requests: [sample_requests.zip](https://github.com/smuellerDD/acvpparser/files/11486777/sample_requests.zip)
