### PR TITLE
List of backend was extended with Intel® IPP Cryptography libraries - ippcp and crypto_mb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ ifeq (leancrypto,$(firstword $(MAKECMDGOALS)))
 	C_SRCS += backends/backend_leancrypto.c
 	INCLUDE_DIRS += backend_interfaces/leancrypto/
 	ifeq ($(uname -m),x86_64)
-		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
+		CFLAGS += -mavx2 -mbmi2 -mpopcnt
 	endif
 	LIBRARIES += leancrypto
 endif

--- a/Makefile
+++ b/Makefile
@@ -350,11 +350,18 @@ ifeq (ippcrypto,$(firstword $(MAKECMDGOALS)))
 	ifeq ($(uname -m),x86_64)
 		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
 	endif
-	LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
+	CFLAGS += -Wno-uninitialized
+
+	# Static link for lnx
+	ifeq ($(UNAME_S),Linux)
+		LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
+		LIBRARIES += crypto ssl
+	else
+		LDFLAGS += -L $(IPPCRYPTOROOT)/lib/
+		LIBRARIES += crypto ssl ippcp
+	endif
 	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/
 	LD_LIBRARY_PATH += $(OPENSSL_ROOT_DIR)/lib64/
-
-	LIBRARIES += crypto ssl
 
 endif
 
@@ -368,14 +375,18 @@ ifeq (cryptomb,$(firstword $(MAKECMDGOALS)))
 	ifeq ($(uname -m),x86_64)
 		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
 	endif
-	CFLAGS += -Wno-unused-variable -Wno-incompatible-pointer-types
-	LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a
-	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/
-	LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
+	CFLAGS += -Wno-incompatible-pointer-types
+
+	ifeq ($(UNAME_S),Linux)
+		LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a $(IPPCRYPTOROOT)/lib/libippcp.a
+		LIBRARIES += crypto ssl
+	else
+		LDFLAGS += -L $(IPPCRYPTOROOT)/lib/
+		LIBRARIES += crypto ssl ippcp crypto_mb
+	endif
+
+	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/ -L $(OPENSSL_ROOT_DIR)/bin/
 	LD_LIBRARY_PATH += $(OPENSSL_ROOT_DIR)/lib64/
-
-	LIBRARIES += crypto ssl
-
 endif
 
 ################## CONFIGURE BACKEND cryptombssl ################
@@ -388,16 +399,20 @@ ifeq (cryptombssl,$(firstword $(MAKECMDGOALS)))
 	ifeq ($(uname -m),x86_64)
 		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
 	endif
-	CFLAGS += -Wno-unused-variable -Wno-incompatible-pointer-types
-	LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a
-	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/
-	LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
+	CFLAGS += -Wno-unused-function -Wno-incompatible-pointer-types
 
+	ifeq ($(UNAME_S),Linux)
+		LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a $(IPPCRYPTOROOT)/lib/libippcp.a
+		LIBRARIES += crypto ssl
+	else
+	    LDFLAGS += -L $(IPPCRYPTOROOT)/lib/
+		LIBRARIES += crypto ssl ippcp crypto_mb
+	endif
+
+	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/ -L $(OPENSSL_ROOT_DIR)/bin/
 	LD_LIBRARY_PATH += $(OPENSSL_ROOT_DIR)/lib64/
-
-	LIBRARIES += crypto ssl
-
 endif
+
 ######################################################
 
 

--- a/Makefile
+++ b/Makefile
@@ -335,10 +335,71 @@ ifeq (leancrypto,$(firstword $(MAKECMDGOALS)))
 	C_SRCS += backends/backend_leancrypto.c
 	INCLUDE_DIRS += backend_interfaces/leancrypto/
 	ifeq ($(uname -m),x86_64)
-		CFLAGS += -mavx2 -mbmi2 -mpopcnt
+		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
 	endif
 	LIBRARIES += leancrypto
 endif
+
+################## CONFIGURE BACKEND ippcrypto ################
+
+ifeq (ippcrypto,$(firstword $(MAKECMDGOALS)))
+	C_SRCS += backends/backend_ippcrypto.c
+	INCLUDE_DIRS += $(IPPCRYPTOROOT)/include
+	INCLUDE_DIRS += $(OPENSSL_ROOT_DIR)/include/
+
+	ifeq ($(uname -m),x86_64)
+		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
+	endif
+	LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
+	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/
+	LD_LIBRARY_PATH += $(OPENSSL_ROOT_DIR)/lib64/
+
+	LIBRARIES += crypto ssl
+
+endif
+
+################## CONFIGURE BACKEND cryptomb ################
+
+ifeq (cryptomb,$(firstword $(MAKECMDGOALS)))
+	C_SRCS += backends/backend_cryptomb.c
+	INCLUDE_DIRS += $(IPPCRYPTOROOT)/include
+	INCLUDE_DIRS += $(OPENSSL_ROOT_DIR)/include/
+
+	ifeq ($(uname -m),x86_64)
+		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
+	endif
+	CFLAGS += -Wno-unused-variable -Wno-incompatible-pointer-types
+	LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a
+	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/
+	LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
+	LD_LIBRARY_PATH += $(OPENSSL_ROOT_DIR)/lib64/
+
+	LIBRARIES += crypto ssl
+
+endif
+
+################## CONFIGURE BACKEND cryptombssl ################
+
+ifeq (cryptombssl,$(firstword $(MAKECMDGOALS)))
+	C_SRCS += backends/backend_cryptombssl.c
+	INCLUDE_DIRS += $(IPPCRYPTOROOT)/include
+	INCLUDE_DIRS += $(OPENSSL_ROOT_DIR)/include/
+
+	ifeq ($(uname -m),x86_64)
+		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
+	endif
+	CFLAGS += -Wno-unused-variable -Wno-incompatible-pointer-types
+	LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a
+	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/
+	LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
+
+	LD_LIBRARY_PATH += $(OPENSSL_ROOT_DIR)/lib64/
+
+	LIBRARIES += crypto ssl
+
+endif
+######################################################
+
 
 ######################################################
 
@@ -359,10 +420,10 @@ LDFLAGS += $(foreach library,$(LIBRARIES),-l$(library))
 analyze_srcs = $(filter %.c, $(sort $(C_SRCS)))
 analyze_plists = $(analyze_srcs:%.c=%.plist)
 
-.PHONY: clean distclean acvp2cavs cavs2acvp kcapi kcapi_lrng libkcapi libgcrypt nettle gnutls openssl nss commoncrypto corecrypto openssh strongswan libreswan acvpproxy libsodium libnacl boringssl botan bouncycastle libica cpacf lrng jent leancrypto shlib shlib_static default files
+.PHONY: clean distclean acvp2cavs cavs2acvp kcapi kcapi_lrng libkcapi libgcrypt nettle gnutls openssl nss commoncrypto corecrypto openssh strongswan libreswan acvpproxy libsodium libnacl boringssl botan bouncycastle libica cpacf lrng jent leancrypto ippcrypto cryptomb cryptombssl shlib shlib_static default files
 
 default:
-	$(error "Usage: make <acvp2cavs|cavs2acvp|kcapi|kcapi_lrng|libkcapi|libgcrypt|nettle|gnutls|openssl|nss|commoncrypto|corecrypto-dispatch|corecypto|openssh|strongswan|libreswan|acvpproxy|libsodium|libnacl|boringssl|apple-boringssl|botan|bouncycastle|libica|cpacf|lrng|jent|leancrypto|shlib|shlib_static>")
+	$(error "Usage: make <acvp2cavs|cavs2acvp|kcapi|kcapi_lrng|libkcapi|libgcrypt|nettle|gnutls|openssl|nss|commoncrypto|corecrypto-dispatch|corecypto|openssh|strongswan|libreswan|acvpproxy|libsodium|libnacl|boringssl|apple-boringssl|botan|bouncycastle|libica|cpacf|lrng|jent|leancrypto|ippcrypto|cryptomb|cryptombssl|shlib|shlib_static>")
 
 acvp2cavs: $(NAME)
 cavs2acvp: $(NAME)
@@ -391,6 +452,9 @@ cpacf: $(NAME)
 lrng: $(NAME)
 jent: $(NAME)
 leancrypto: $(NAME)
+ippcrypto: $(NAME)
+cryptomb: $(NAME)
+cryptombssl: $(NAME)
 shlib: $(SHLIB_NAME)
 shlib_static: $(SHLIB_NAME_STATIC)
 bouncycastle: $(NAME)

--- a/backends/backend_cryptomb.c
+++ b/backends/backend_cryptomb.c
@@ -148,7 +148,6 @@ static int cryptomb_ecdsa_keygen_en(uint64_t curve, struct buffer *Qx_buf,
     memset(Qy_buf->buf, 0, len8);
     reverse_bytes(Qy_buf->buf, data_pub_y, Qy_buf->len);
 
-out:
 	return ret;
 }
 
@@ -193,6 +192,7 @@ static int cryptomb_ecdsa_keygen(struct ecdsa_keygen_data *data, flags_t parsed_
 
     EVP_PKEY* ecKeyPair = 0;
     ecKeyPair = openssl_generate_keys(pa_prvB[0], NULL, NULL, NULL, EC, curvename, len8, len64, 0);
+    (void)ecKeyPair;
 
     for(int i = 1; i < MBX_NUM_BUFFERS; i++) {
             memcpy(pa_prvB[i], pa_prvB[0], len8);
@@ -405,7 +405,6 @@ static int cryptomb_ecdsa_sigver(struct ecdsa_sigver_data *data, flags_t parsed_
         data->sigver_success = 0;
     }
 
-out:
     return ret;
 }
 
@@ -453,6 +452,7 @@ static int cryptomb_ecdh_common(uint64_t cipher, struct buffer *Qxrem, struct bu
 		default:
 			logger(LOGGER_ERR, "Unknown curve\n");
 	}
+    (void)add;
     set_ec_params(ec);
 
     // A - remote
@@ -480,6 +480,8 @@ static int cryptomb_ecdh_common(uint64_t cipher, struct buffer *Qxrem, struct bu
         // generate local keys
         EVP_PKEY* ecKeyPair = 0;
         ecKeyPair = openssl_generate_keys(pa_prvB[0], NULL, NULL, NULL, EC, curvename, len8, len64, 0);
+        (void)ecKeyPair;
+
         for(int i = 1; i < MBX_NUM_BUFFERS; i++) {
             memcpy(pa_prvB[i], pa_prvB[0], len8);
         }
@@ -664,7 +666,7 @@ static int cryptomb_eddsa_keygen(struct eddsa_keygen_data *data, flags_t parsed_
     }
 
     // extract private and public kyes considered as "known"
-    size_t privale_len = 32, public_len = 32;
+    size_t privale_len = 32;
     if(1 != EVP_PKEY_get_raw_private_key(key, priv_key, &privale_len)) {
         logger(LOGGER_ERR, "Error in EVP_PKEY_get_raw_private_key\n");
     }
@@ -791,7 +793,6 @@ static int cryptomb_eddsa_sigver(struct eddsa_sigver_data *data, flags_t parsed_
         data->sigver_success = 0;
     }
 
-out:
     free(msg);
     free(public_key);
 
@@ -850,11 +851,6 @@ static int cryptomb_rsa_kas_ifc_encrypt_common(struct kts_ifc_data *data, uint32
     int8u *pa_ciphertext[MBX_NUM_BUFFERS] = {
         out_ciphertext[0], out_ciphertext[1], out_ciphertext[2], out_ciphertext[3],
         out_ciphertext[4], out_ciphertext[5], out_ciphertext[6], out_ciphertext[7]};
-
-    // plaintext
-    const int8u *pa_plaintext[MBX_NUM_BUFFERS] = {
-        dkm_p->buf, dkm_p->buf, dkm_p->buf, dkm_p->buf,
-        dkm_p->buf, dkm_p->buf, dkm_p->buf, dkm_p->buf};
 
     // moduli
     int8u* pN = malloc(init->n.len);

--- a/backends/backend_cryptomb.c
+++ b/backends/backend_cryptomb.c
@@ -1,0 +1,1192 @@
+/*************************************************************************
+* Copyright (C) 2024 Intel Corporation
+*
+* Licensed under the Apache License,  Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* 	http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law  or agreed  to  in  writing,  software
+* distributed under  the License  is  distributed  on  an  "AS IS"  BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the  specific  language  governing  permissions  and
+* limitations under the License.
+*************************************************************************/
+
+#include <strings.h>
+#include <ctype.h>
+
+#include "backend_common.h"
+#include "backend_cryptomb_common.h"
+
+static int len64, len8, msglen;
+
+// globals (group)
+static EC_GROUP* EC = NULL;
+static const char *curvename;
+
+/************************************************
+ * ECDSA interface functions
+ ************************************************/
+typedef mbx_status (*p_mbx_nistp_ecpublic_key_mb8)(int64u**, int64u**, int64u**, const int64u** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_sign_mb8)(int8u**, int8u**, const int8u** const, const int64u** const, const int64u** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_sign_setup_mb8)(int64u**, int64u**, const int64u** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_sign_complete_mb8)(int8u**, int8u**, const int8u** const, const int64u** const, const int64u** const, const int64u** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_verify_mb8)(const int8u** const, const int8u** const, const int8u** const, const int64u** const, const int64u** const, const int64u** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdh_mb8)(int8u**, const int64u**, const int64u**, const int64u**, const int64u**, int8u*);
+
+static p_mbx_nistp_ecpublic_key_mb8 mbx_nistp_ecpublic_key_mb8 = NULL;
+static p_mbx_nistp_ecdsa_sign_mb8 mbx_nistp_ecdsa_sign_mb8 = NULL;
+static p_mbx_nistp_ecdsa_sign_setup_mb8 mbx_nistp_ecdsa_sign_setup_mb8 = NULL;
+static p_mbx_nistp_ecdsa_sign_complete_mb8 mbx_nistp_ecdsa_sign_complete_mb8 = NULL;
+static p_mbx_nistp_ecdsa_verify_mb8 mbx_nistp_ecdsa_verify_mb8 = NULL;
+static p_mbx_nistp_ecdh_mb8 mbx_nistp_ecdh_mb8 = NULL;
+
+static void set_ec_params(ec_type ec)
+{
+    switch (ec)
+    {
+    case nistp256:
+        EC = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
+        curvename = "P-256";
+        len64 = GF256_LEN64;
+        len8 = GF256_LEN8;
+        mbx_nistp_ecpublic_key_mb8 = mbx_nistp256_ecpublic_key_mb8;
+        mbx_nistp_ecdsa_sign_mb8 = mbx_nistp256_ecdsa_sign_mb8;
+        mbx_nistp_ecdsa_sign_setup_mb8 = mbx_nistp256_ecdsa_sign_setup_mb8;
+        mbx_nistp_ecdsa_sign_complete_mb8 = mbx_nistp256_ecdsa_sign_complete_mb8;
+        mbx_nistp_ecdsa_verify_mb8 = mbx_nistp256_ecdsa_verify_mb8;
+        mbx_nistp_ecdh_mb8 = mbx_nistp256_ecdh_mb8;
+        msglen = GF256_BITLEN;
+        break;
+    case nistp384:
+        EC = EC_GROUP_new_by_curve_name(NID_secp384r1);
+        curvename = "P-384";
+        len64 = GF384_LEN64;
+        len8 = GF384_LEN8;
+        mbx_nistp_ecpublic_key_mb8 = mbx_nistp384_ecpublic_key_mb8;
+        mbx_nistp_ecdsa_sign_mb8 = mbx_nistp384_ecdsa_sign_mb8;
+        mbx_nistp_ecdsa_sign_setup_mb8 = mbx_nistp384_ecdsa_sign_setup_mb8;
+        mbx_nistp_ecdsa_sign_complete_mb8 = mbx_nistp384_ecdsa_sign_complete_mb8;
+        mbx_nistp_ecdsa_verify_mb8 = mbx_nistp384_ecdsa_verify_mb8;
+        mbx_nistp_ecdh_mb8 = mbx_nistp384_ecdh_mb8;
+        msglen = GF384_BITLEN;
+        break;
+    case nistp521:
+        EC = EC_GROUP_new_by_curve_name(NID_secp521r1);
+        curvename = "P-521";
+        len64 = GF521_LEN64;
+        len8 = GF521_LEN8;
+        mbx_nistp_ecpublic_key_mb8 = mbx_nistp521_ecpublic_key_mb8;
+        mbx_nistp_ecdsa_sign_mb8 = mbx_nistp521_ecdsa_sign_mb8;
+        mbx_nistp_ecdsa_sign_setup_mb8 = mbx_nistp521_ecdsa_sign_setup_mb8;
+        mbx_nistp_ecdsa_sign_complete_mb8 = mbx_nistp521_ecdsa_sign_complete_mb8;
+        mbx_nistp_ecdsa_verify_mb8 = mbx_nistp521_ecdsa_verify_mb8;
+        mbx_nistp_ecdh_mb8 = mbx_nistp521_ecdh_mb8;
+        // length of msg must be mutiple 8 (OpenSSL specific)
+        msglen = GF521_BITLEN - (GF521_BITLEN % 8);
+        break;
+    default:
+        break;
+    }
+}
+
+typedef struct {
+    EVP_PKEY* pEcKeyPair;
+    int8u*    pRegKey;
+} pKeys;
+
+static int cryptomb_ecdsa_keygen_en(uint64_t curve, struct buffer *Qx_buf,
+				                    struct buffer *Qy_buf, void **privkey)
+{
+    (void)Qx_buf; (void)Qy_buf; (void)privkey;
+    int ret = 0;
+
+    ec_type ec = ec_unset;
+    switch (curve & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+    set_ec_params(ec);
+
+    // ifma's regular private key and public key
+     __ALIGN64 int64u st_reg_skey[MAX_LEN64];
+     __ALIGN64 int64u data_pub_x[MAX_LEN64];
+     __ALIGN64 int64u data_pub_y[MAX_LEN64];
+
+    EVP_PKEY* ecKeyPair = 0;
+    ecKeyPair = openssl_generate_keys(st_reg_skey, data_pub_x, data_pub_y, NULL, EC, curvename, len8, len64, 0);
+
+    BUFFER_INIT(reg_skey)
+    alloc_buf(MAX_LEN8, &reg_skey);
+    memcpy(reg_skey.buf, st_reg_skey, MAX_LEN8);
+
+    (void)ecKeyPair;
+    pKeys* sslPrivKey = ( pKeys* )malloc(sizeof( pKeys));
+    sslPrivKey->pEcKeyPair = ecKeyPair;
+    sslPrivKey->pRegKey = reg_skey.buf;
+
+    *privkey = sslPrivKey;
+
+    /* Get X component of pub key */
+    alloc_buf(len8, Qx_buf);
+    memset(Qx_buf->buf, 0, len8);
+    reverse_bytes(Qx_buf->buf, data_pub_x, Qx_buf->len);
+
+    /* Get Y component of pub key */
+    alloc_buf(len8, Qy_buf);
+    memset(Qy_buf->buf, 0, len8);
+    reverse_bytes(Qy_buf->buf, data_pub_y, Qy_buf->len);
+
+out:
+	return ret;
+}
+
+static void cryptomb_ecdsa_free_key(void *privkey)
+{
+    (void)privkey;
+
+    EC_GROUP_free(EC);
+
+    pKeys* sslPrivKey = ( pKeys* )privkey;
+    EVP_PKEY_free(sslPrivKey->pEcKeyPair);
+    free_buf(&sslPrivKey->pRegKey);
+    free(sslPrivKey);
+}
+
+static int cryptomb_ecdsa_keygen(struct ecdsa_keygen_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+    int ret = 0;
+    mbx_status sts = MBX_STATUS_OK;
+
+    ec_type ec = ec_unset;
+    switch (data->cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+    set_ec_params(ec);
+
+    // local regular private and public keys
+    create_and_clean_mbx_buffer_int64u(prvB);
+    create_and_clean_mbx_buffer_int64u(pubBx);
+    create_and_clean_mbx_buffer_int64u(pubBy);
+
+    EVP_PKEY* ecKeyPair = 0;
+    ecKeyPair = openssl_generate_keys(pa_prvB[0], NULL, NULL, NULL, EC, curvename, len8, len64, 0);
+
+    for(int i = 1; i < MBX_NUM_BUFFERS; i++) {
+            memcpy(pa_prvB[i], pa_prvB[0], len8);
+    }
+    sts = mbx_nistp_ecpublic_key_mb8(pa_pubBx, pa_pubBy, NULL, (const int64u**)pa_prvB, 0);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecpublic_key_mb8")
+
+    /* Output the private key */
+    alloc_buf(len8, &data->d);
+    memset(data->d.buf, 0, len8);
+    reverse_bytes(data->d.buf, pa_prvB[0], len8);
+
+    /* Get X component of pub key */
+    alloc_buf(len8, &data->Qx);
+    memset(data->Qx.buf, 0, len8);
+    reverse_bytes(data->Qx.buf, pa_pubBx[0], len8);
+
+    /* Get Y component of pub key */
+    alloc_buf(len8, &data->Qy);
+    memset(data->Qy.buf, 0, len8);
+    reverse_bytes(data->Qy.buf, pa_pubBy[0], len8);
+
+out:
+    return ret;
+}
+
+static int cryptomb_ecdsa_siggen(struct ecdsa_siggen_data *data, flags_t parsed_flags)
+{
+    (void)parsed_flags; (void)data;
+    int ret = 0;
+
+    ec_type ec = ec_unset;
+
+    int add = 0;
+    switch (data->cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+            add = 2;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+    (void)ec; (void)add;
+
+    // message
+    int msgByteSize = data->msg.len;
+    int8u data_msg_digest[MBX_NUM_BUFFERS][maxMsgDigestSize] = { 0 };
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        memcpy(data_msg_digest[i]+add, data->msg.buf, msgByteSize);
+    }
+    int8u* pa_msg_digest[MBX_NUM_BUFFERS] = {data_msg_digest[0], data_msg_digest[1], data_msg_digest[2], data_msg_digest[3],
+                                             data_msg_digest[4], data_msg_digest[5], data_msg_digest[6], data_msg_digest[7]};
+    BIGNUM* bn_msg = BN_new();
+    BN_hex2bn(&bn_msg, (char*)data_msg_digest[0]);
+
+    create_and_clean_mbx_buffer_int64u(eph_skey);
+    create_and_clean_mbx_buffer_int64u(reg_skey);
+
+    pKeys* sslPrivKey = (pKeys*)data->privkey;
+
+    memcpy(reg_skey[0], sslPrivKey->pRegKey, len8);
+
+    ECDSA_SIG* sign = openssl_generate_signature(data_msg_digest[0], BN_num_bytes(bn_msg), sslPrivKey->pEcKeyPair);
+
+    // reference to sign' components
+    const BIGNUM* signR = 0; const BIGNUM* signS = 0;
+    ECDSA_SIG_get0(sign, &signR, &signS);
+
+    openssl_restore_eph_key(eph_skey[0], reg_skey[0], signR, signS, bn_msg, len8, len64, EC);
+
+    for(int i = 1; i < MBX_NUM_BUFFERS; i++) {
+        memcpy(reg_skey[i], reg_skey[0], len8);
+        memcpy(eph_skey[i], eph_skey[0], len8);
+    }
+
+    /* Output signature */
+    create_and_clean_mbx_buffer_int8u(sign_r);
+    create_and_clean_mbx_buffer_int8u(sign_s);
+    create_and_clean_mbx_buffer_int8u(sign_r_partial_api);
+    create_and_clean_mbx_buffer_int8u(sign_s_partial_api);
+
+    /* Main API*/
+    mbx_status sts = mbx_nistp_ecdsa_sign_mb8(pa_sign_r, pa_sign_s,
+                                            (const int8u**)pa_msg_digest,
+                                            (const int64u**)pa_eph_skey,
+                                            (const int64u**)pa_reg_skey,
+                                            0);
+
+    /* Partial API */
+    create_and_clean_mbx_buffer_int64u(sign_rp);
+    create_and_clean_mbx_buffer_int64u(inv_eph_skey);
+
+    mbx_status sts_partial = mbx_nistp_ecdsa_sign_setup_mb8(pa_inv_eph_skey, pa_sign_rp, pa_eph_skey, NULL);
+    CKNULL_LOG((sts_partial == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecdsa_sign_setup_mb8")
+
+    sts_partial = mbx_nistp_ecdsa_sign_complete_mb8(pa_sign_r_partial_api, pa_sign_s_partial_api, pa_msg_digest,
+       (const int64u**)pa_sign_rp, (const int64u**)pa_inv_eph_skey, pa_reg_skey, NULL);
+    CKNULL_LOG((sts_partial == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecdsa_sign_complete_mb8")
+
+
+    /* Check that all buffers are the same before write the answer */
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        int flag_r = memcmp(pa_sign_r[0], pa_sign_r[i], len8) || memcmp(pa_sign_r[0], pa_sign_r_partial_api[i], len8);
+        int flag_s = memcmp(pa_sign_s[0], pa_sign_s[i], len8) || memcmp(pa_sign_s[0], pa_sign_s_partial_api[i], len8);
+
+        if(flag_r || flag_s) {
+			logger(LOGGER_ERR, "Result NOT VALID, buffers differ\n");
+            sts = MBX_SET_STS_ALL(MBX_STATUS_MISMATCH_PARAM_ERR);
+            break;
+        }
+    }
+
+    if(sts == MBX_STATUS_OK) {
+        /* Get S component */
+        alloc_buf(len8, &data->S);
+        memset(data->S.buf, 0, len8);
+        memcpy(data->S.buf, pa_sign_s[0], len8);
+
+        /* Get R component */
+        alloc_buf(len8, &data->R);
+        memset(data->R.buf, 0, len8);
+        memcpy(data->R.buf, pa_sign_r[0], len8);
+    }
+
+out:
+    BN_free(bn_msg);
+    ECDSA_SIG_free(sign);
+
+    return ret;
+}
+
+static int cryptomb_ecdsa_sigver(struct ecdsa_sigver_data *data, flags_t parsed_flags)
+{
+    (void)parsed_flags;
+    int ret = 0;
+
+    /* "Feature" of p521 curve - pad the message with leading zeros to 528 bits */
+    int offset = 0;
+    ec_type ec = ec_unset;
+    switch (data->cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+            offset = 2;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+
+    set_ec_params(ec);
+
+    int8u data_sig_r[MBX_NUM_BUFFERS][maxMsgDigestSize] = { 0 };
+    int8u data_sig_s[MBX_NUM_BUFFERS][maxMsgDigestSize] = { 0 };
+    int8u data_msg_digest[MBX_NUM_BUFFERS][maxMsgDigestSize] = { 0 };
+
+    /* public X | Y | Z */
+    int64u data_pub_x_init[MBX_NUM_BUFFERS][maxSize64u] = { 0 };
+    int64u data_pub_y_init[MBX_NUM_BUFFERS][maxSize64u] = { 0 };
+    int64u data_pub_x[MBX_NUM_BUFFERS][maxSize64u] = { 0 };
+    int64u data_pub_y[MBX_NUM_BUFFERS][maxSize64u] = { 0 };
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        memcpy(data_sig_s[i], data->S.buf,data->S.len);
+        memcpy(data_sig_r[i], data->R.buf,data->R.len);
+        memcpy(data_msg_digest[i]+offset, data->msg.buf, data->msg.len);
+
+        memcpy(data_pub_x_init[i], data->Qx.buf,data->Qx.len);
+        reverse_bytes((int8u*)data_pub_x[i], (int8u*)data_pub_x_init[i], data->Qx.len);
+
+        memcpy(data_pub_y_init[i], data->Qy.buf,data->Qy.len);
+        reverse_bytes((int8u*)data_pub_y[i], (int8u*)data_pub_y_init[i], data->Qy.len);
+    }
+
+    /* signature */
+    int8u* pa_sig_r[MBX_NUM_BUFFERS] = {data_sig_r[0], data_sig_r[1], data_sig_r[2], data_sig_r[3],
+                                  data_sig_r[4], data_sig_r[5], data_sig_r[6], data_sig_r[7]};
+    int8u* pa_sig_s[MBX_NUM_BUFFERS] = {data_sig_s[0], data_sig_s[1], data_sig_s[2], data_sig_s[3],
+                                  data_sig_s[4], data_sig_s[5], data_sig_s[6], data_sig_s[7]};
+
+    /* msg */
+    int8u* pa_msg_digest[MBX_NUM_BUFFERS] = {data_msg_digest[0], data_msg_digest[1], data_msg_digest[2], data_msg_digest[3],
+                                       data_msg_digest[4], data_msg_digest[5], data_msg_digest[6], data_msg_digest[7]};
+
+    /* key */
+    int64u* pa_pub_x[MBX_NUM_BUFFERS] = {data_pub_x[0], data_pub_x[1], data_pub_x[2], data_pub_x[3],
+                                   data_pub_x[4], data_pub_x[5], data_pub_x[6], data_pub_x[7]};
+    int64u* pa_pub_y[MBX_NUM_BUFFERS] = {data_pub_y[0], data_pub_y[1], data_pub_y[2], data_pub_y[3],
+                                   data_pub_y[4], data_pub_y[5], data_pub_y[6], data_pub_y[7]};
+
+    /* Verify */
+    mbx_status sts = 0;
+    sts = mbx_nistp_ecdsa_verify_mb8((const int8u**)pa_sig_r, (const int8u**)pa_sig_s,
+                                     (const int8u**)pa_msg_digest, (const int64u**)pa_pub_x, (const int64u**)pa_pub_y,
+                                     NULL, NULL);
+
+    data->sigver_success = 1;
+    if (MBX_STATUS_OK != sts) {
+        data->sigver_success = 0;
+    }
+
+out:
+    return ret;
+}
+
+static struct ecdsa_backend cryptomb_ecdsa =
+{
+	cryptomb_ecdsa_keygen,   /* ecdsa_keygen_testing */
+	NULL,
+	NULL,                    /* ecdsa_pkvver */
+	cryptomb_ecdsa_siggen,   /* ecdsa_siggen */
+	cryptomb_ecdsa_sigver,   /* ecdsa_sigver */
+	cryptomb_ecdsa_keygen_en,
+	cryptomb_ecdsa_free_key,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_ecdsa_backend)
+static void cryptomb_ecdsa_backend(void)
+{
+	register_ecdsa_impl(&cryptomb_ecdsa);
+}
+
+/************************************************
+ * ECDH interface functions
+ ************************************************/
+static int cryptomb_ecdh_common(uint64_t cipher, struct buffer *Qxrem, struct buffer *Qyrem,
+		                        struct buffer *privloc, struct buffer *Qxloc, struct buffer *Qyloc,
+		                        struct buffer *hashzz)
+{
+    int ret = 0;
+    mbx_status sts = MBX_STATUS_OK;
+
+    ec_type ec = ec_unset;
+
+    int add = 0;
+    switch (cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+            add = 2;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+    set_ec_params(ec);
+
+    // A - remote
+    // B - local
+    create_and_clean_mbx_buffer_int64u(ifma_sharedAB);
+    create_and_clean_mbx_buffer_int64u(pubBx);
+    create_and_clean_mbx_buffer_int64u(pubBy);
+    create_and_clean_mbx_buffer_int64u(pubAx);
+    create_and_clean_mbx_buffer_int64u(pubAy);
+    create_and_clean_mbx_buffer_int64u(prvB);
+
+
+    if (Qxloc->len && Qyloc->len) {
+        for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+            reverse_bytes(pa_pubBx[i], Qxloc->buf, Qxloc->len);
+            reverse_bytes(pa_pubBy[i], Qyloc->buf, Qyloc->len);
+        }
+	}
+    if (privloc->len) {
+        for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+            reverse_bytes(pa_prvB[i], privloc->buf, privloc->len);
+        }
+	}
+    if(!(privloc->len && Qxloc->len && Qyloc->len)) {
+        // generate local keys
+        EVP_PKEY* ecKeyPair = 0;
+        ecKeyPair = openssl_generate_keys(pa_prvB[0], NULL, NULL, NULL, EC, curvename, len8, len64, 0);
+        for(int i = 1; i < MBX_NUM_BUFFERS; i++) {
+            memcpy(pa_prvB[i], pa_prvB[0], len8);
+        }
+
+        sts = mbx_nistp_ecpublic_key_mb8(pa_pubBx, pa_pubBy, NULL, (const int64u**)pa_prvB, 0);
+        CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecpublic_key_mb8")
+
+        alloc_buf(len8, Qxloc);
+        alloc_buf(len8, Qyloc);
+        reverse_bytes(Qxloc->buf, pa_pubBx[0], len8);
+        reverse_bytes(Qyloc->buf, pa_pubBy[0], len8);
+	}
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        reverse_bytes(pa_pubAx[i], Qxrem->buf, Qxrem->len);
+        reverse_bytes(pa_pubAy[i], Qyrem->buf, Qyrem->len);
+    }
+
+    sts = mbx_nistp_ecdh_mb8(pa_ifma_sharedAB, (const int64u**)pa_prvB, (const int64u**)pa_pubAx, (const int64u**)pa_pubAy, NULL, 0);
+
+    for(int i = 1; i < MBX_NUM_BUFFERS; i++){
+        int cmp_flag = memcmp(pa_ifma_sharedAB[i],pa_ifma_sharedAB[0], len8);
+
+        if(cmp_flag){
+			logger(LOGGER_ERR, "Bad result, buffers differ\n");
+            ret = 0;
+            break;
+        }
+    }
+
+    if(hashzz->len){
+        if(memcmp(hashzz->buf, pa_ifma_sharedAB[0], len8)){
+            ret = -ENOENT;
+            goto out;
+        }
+    }
+    else{
+        alloc_buf(len8, hashzz);
+        memcpy(hashzz->buf, pa_ifma_sharedAB[0], len8);
+    }
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecdh_mb8")
+
+
+out:
+
+    return ret;
+}
+
+static int cryptomb_ecdh_ss(struct ecdh_ss_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+	return cryptomb_ecdh_common(data->cipher, &data->Qxrem, &data->Qyrem,
+                                &data->privloc, &data->Qxloc,
+                                &data->Qyloc, &data->hashzz);
+}
+
+static int cryptomb_ecdh_ss_ver(struct ecdh_ss_ver_data *data, flags_t parsed_flags)
+{
+    int ret = 0;
+	(void)parsed_flags;
+
+	ret = cryptomb_ecdh_common(data->cipher, &data->Qxrem,
+                               &data->Qyrem, &data->privloc,
+                               &data->Qxloc, &data->Qyloc,
+                               &data->hashzz);
+
+	if (ret == -EOPNOTSUPP || ret == -ENOENT) {
+		data->validity_success = 0;
+        return 0;
+	} else if (!ret) {
+		data->validity_success = 1;
+        return 0;
+	}
+
+	return ret;
+}
+
+static struct ecdh_backend cryptomb_ecdh =
+{
+	cryptomb_ecdh_ss,
+	cryptomb_ecdh_ss_ver,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_ecdh_backend)
+static void cryptomb_ecdh_backend(void)
+{
+    register_ecdh_impl(&cryptomb_ecdh);
+}
+
+/************************************************
+ * Edward Curve testing
+ ************************************************/
+#define EDDSA_COMPONENT_SIGN_LEN (32)
+
+typedef struct {
+    ed25519_public_key* pub_key_;
+    ed25519_private_key* priv_key_;
+} eddsaKeyPair;
+
+static int  cryptomb_eddsa_keygen_en(struct buffer *qbuf, uint64_t curve, void **privkey)
+{
+    (void)qbuf; (void)curve; (void)privkey;
+    int ret = 0;
+
+    /* Pub key buffer */
+    ed25519_public_key* pub_key = (ed25519_public_key*)malloc(sizeof(ed25519_public_key));
+
+    /* Priv key buffer */
+    ed25519_private_key* priv_key = (ed25519_private_key*)malloc(sizeof(ed25519_private_key));
+
+    EVP_PKEY *key = NULL;
+    EVP_MD_CTX* md_ctx = EVP_MD_CTX_new();
+
+    EVP_PKEY_CTX* key_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, NULL); //get EVP_PKEY context
+    EVP_PKEY_keygen_init(key_ctx); // init EVP_PKEY context
+
+    // generate key pair using OpenSSL
+    int evpres = EVP_PKEY_keygen(key_ctx, &key);
+    CKNULL_LOG((evpres == 1), evpres, "Error in EVP_PKEY_keygen")
+
+    EVP_PKEY_CTX_free(key_ctx);
+    key_ctx = NULL;
+
+    EVP_DigestSignInit(md_ctx, &key_ctx, NULL, NULL, key);
+
+    // extract private and public kyes considered as "known"
+    size_t privale_len = 32, public_len = 32;
+    if(1 != EVP_PKEY_get_raw_private_key(key, priv_key, &privale_len)) {
+        logger(LOGGER_ERR, "Error in EVP_PKEY_get_raw_private_key\n");
+    }
+    if(1 != EVP_PKEY_get_raw_public_key(key, pub_key, &public_len)) {
+        logger(LOGGER_ERR, "Error in EVP_PKEY_get_raw_public_key\n");
+    }
+
+    eddsaKeyPair* keyPair = (eddsaKeyPair*)malloc(sizeof(eddsaKeyPair));
+    keyPair->pub_key_ = pub_key;
+    keyPair->priv_key_ = priv_key;
+
+    *privkey = keyPair;
+out:
+    return ret;
+}
+
+static void cryptomb_eddsa_free_key(void *privkey)
+{
+    eddsaKeyPair* keyPair = (eddsaKeyPair*)privkey;
+
+    free(keyPair->pub_key_);
+    free(keyPair->priv_key_);
+    free(keyPair);
+}
+
+static int cryptomb_eddsa_keygen(struct eddsa_keygen_data *data, flags_t parsed_flags)
+{
+    int ret = 0;
+    (void)parsed_flags;
+    mbx_status sts = MBX_STATUS_OK;
+
+    EVP_PKEY_CTX* key_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, NULL); //get EVP_PKEY context
+    EVP_PKEY_keygen_init(key_ctx); // init EVP_PKEY context
+    EVP_PKEY *key = NULL;
+
+    ed25519_public_key public_key[8];
+    /* Priv key buffer */
+    ed25519_private_key* priv_key = (ed25519_private_key*)malloc(sizeof(ed25519_private_key));
+
+    /* Array of pointers */
+    ed25519_public_key* pa_public_key[8] = {
+        &public_key[0], &public_key[1], &public_key[2], &public_key[3],
+        &public_key[4], &public_key[5], &public_key[6], &public_key[7]
+    };
+    ed25519_private_key* pa_secret_key[8] = {
+      priv_key, priv_key, priv_key, priv_key,
+      priv_key, priv_key, priv_key, priv_key
+   };
+
+    // generate key pair using OpenSSL
+    int evpres = EVP_PKEY_keygen(key_ctx, &key);
+    if(1!=evpres) {
+        logger(LOGGER_ERR, "Error in EVP_PKEY_keygen\n");
+    }
+
+    // extract private and public kyes considered as "known"
+    size_t privale_len = 32, public_len = 32;
+    if(1 != EVP_PKEY_get_raw_private_key(key, priv_key, &privale_len)) {
+        logger(LOGGER_ERR, "Error in EVP_PKEY_get_raw_private_key\n");
+    }
+
+    sts =  mbx_ed25519_public_key_mb8(pa_public_key, pa_secret_key);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_ed25519_public_key_mb8")
+
+    for(int i = 1; i < MBX_NUM_BUFFERS; i++){
+        int cmp_flag = memcmp(pa_public_key[i], pa_public_key[0], EDDSA_COMPONENT_SIGN_LEN);
+        if(cmp_flag) logger(LOGGER_ERR, "Results are not valid, buffers are different\n");
+    }
+
+    alloc_buf(EDDSA_COMPONENT_SIGN_LEN, &data->d);
+    memcpy(data->d.buf, priv_key, EDDSA_COMPONENT_SIGN_LEN);
+
+    alloc_buf(EDDSA_COMPONENT_SIGN_LEN, &data->q);
+    memcpy(data->q.buf, pa_public_key[0], EDDSA_COMPONENT_SIGN_LEN);
+
+out:
+    free(priv_key);
+    return ret;
+}
+
+static int cryptomb_eddsa_siggen(struct eddsa_siggen_data *data, flags_t parsed_flags) {
+    (void)parsed_flags; (void)data;
+    int ret = 0;
+    mbx_status sts;
+
+    /* output signature */
+    ed25519_sign_component out_r[MBX_NUM_BUFFERS] = {0};
+    ed25519_sign_component out_s[MBX_NUM_BUFFERS] = {0};
+    ed25519_sign_component *pa_sign_r[MBX_NUM_BUFFERS] = { (ed25519_sign_component *)out_r[0], (ed25519_sign_component *)out_r[1],
+                                                     (ed25519_sign_component *)out_r[2], (ed25519_sign_component *)out_r[3],
+                                                     (ed25519_sign_component *)out_r[4], (ed25519_sign_component *)out_r[5],
+                                                     (ed25519_sign_component *)out_r[6], (ed25519_sign_component *)out_r[7]};
+    ed25519_sign_component *pa_sign_s[MBX_NUM_BUFFERS] = { (ed25519_sign_component *)out_s[0], (ed25519_sign_component *)out_s[1],
+                                                     (ed25519_sign_component *)out_s[2], (ed25519_sign_component *)out_s[3],
+                                                     (ed25519_sign_component *)out_s[4], (ed25519_sign_component *)out_s[5],
+                                                     (ed25519_sign_component *)out_s[6], (ed25519_sign_component *)out_s[7]};
+
+    /* Set up message*/
+    int msgLen = data->msg.len;
+    int8u* msg = malloc(msgLen);
+    memcpy(msg, data->msg.buf, msgLen);
+    int8u* pa_msg[8]    = { msg, msg, msg, msg, msg, msg, msg, msg };
+    int32u msgLenArr[8] = { msgLen, msgLen, msgLen, msgLen, msgLen, msgLen, msgLen, msgLen };
+
+    /* Key pair */
+    eddsaKeyPair* keyPair = (eddsaKeyPair*)data->privkey;
+
+    /* Set up private key */
+    ed25519_private_key prv_key;
+    memcpy(prv_key, keyPair->priv_key_, EDDSA_COMPONENT_SIGN_LEN);
+    const ed25519_private_key *const pa_prv_key[MBX_NUM_BUFFERS] = { (const ed25519_private_key *const)&prv_key, (const ed25519_private_key *const)&prv_key,
+                                                                     (const ed25519_private_key *const)&prv_key, (const ed25519_private_key *const)&prv_key,
+                                                                     (const ed25519_private_key *const)&prv_key, (const ed25519_private_key *const)&prv_key,
+                                                                     (const ed25519_private_key *const)&prv_key, (const ed25519_private_key *const)&prv_key };
+    /* Set up public key */
+    ed25519_public_key pub_key;
+    memcpy(pub_key, keyPair->pub_key_, EDDSA_COMPONENT_SIGN_LEN);
+    const ed25519_public_key *const pa_pub_key[MBX_NUM_BUFFERS] = { (const ed25519_private_key *const)&pub_key, (const ed25519_private_key *const)&pub_key,
+                                                                    (const ed25519_private_key *const)&pub_key, (const ed25519_private_key *const)&pub_key,
+                                                                    (const ed25519_private_key *const)&pub_key, (const ed25519_private_key *const)&pub_key,
+                                                                    (const ed25519_private_key *const)&pub_key, (const ed25519_private_key *const)&pub_key };
+
+    /* Sign the message */
+    sts = mbx_ed25519_sign_mb8(pa_sign_r, pa_sign_s, pa_msg, msgLenArr, pa_prv_key, pa_pub_key);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_ed25519_sign_mb8")
+
+    /* Output the result */
+    alloc_buf(2*EDDSA_COMPONENT_SIGN_LEN, &data->signature);
+    memcpy(data->signature.buf, pa_sign_r[0], EDDSA_COMPONENT_SIGN_LEN);
+    memcpy(data->signature.buf+EDDSA_COMPONENT_SIGN_LEN, pa_sign_s[0], EDDSA_COMPONENT_SIGN_LEN);
+
+    alloc_buf(EDDSA_COMPONENT_SIGN_LEN, &data->q);
+    memcpy(data->q.buf, pub_key, EDDSA_COMPONENT_SIGN_LEN);
+
+out:
+    free(msg);
+
+    return ret;
+}
+
+static int cryptomb_eddsa_sigver(struct eddsa_sigver_data *data, flags_t parsed_flags) {
+    (void)parsed_flags;
+    int ret = 0;
+    mbx_status sts = MBX_STATUS_OK;
+
+    ed25519_sign_component sign_r[8];
+    ed25519_sign_component sign_s[8];
+    ed25519_sign_component* pa_sign_r[8] = { &sign_r[0], &sign_r[1], &sign_r[2], &sign_r[3], &sign_r[4], &sign_r[5], &sign_r[6], &sign_r[7] };
+    ed25519_sign_component* pa_sign_s[8] = { &sign_s[0], &sign_s[1], &sign_s[2], &sign_s[3], &sign_s[4], &sign_s[5], &sign_s[6], &sign_s[7] };
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++){
+        memcpy(sign_r[i], data->signature.buf, EDDSA_COMPONENT_SIGN_LEN);
+        memcpy(sign_s[i], data->signature.buf+EDDSA_COMPONENT_SIGN_LEN, EDDSA_COMPONENT_SIGN_LEN);
+    }
+
+    /* Set message */
+    int msgLen = data->msg.len;
+    int8u* msg = malloc(msgLen);
+    memcpy(msg, data->msg.buf, msgLen);
+    int8u* pa_msg[8] = { msg, msg, msg, msg, msg, msg, msg, msg };
+
+    int32u msgLenArr[8] = { msgLen, msgLen, msgLen, msgLen, msgLen, msgLen, msgLen, msgLen };
+
+    /* Set public key */
+    int8u* public_key = malloc(data->q.len);
+    memcpy(public_key, data->q.buf, data->q.len);
+    ed25519_public_key* pa_public_key[8] = { (ed25519_public_key*)public_key, (ed25519_public_key*)public_key,
+                                             (ed25519_public_key*)public_key, (ed25519_public_key*)public_key,
+                                             (ed25519_public_key*)public_key, (ed25519_public_key*)public_key,
+                                             (ed25519_public_key*)public_key, (ed25519_public_key*)public_key };
+
+    sts =  mbx_ed25519_verify_mb8((const ed25519_sign_component**)pa_sign_r,
+                                  (const ed25519_sign_component**)pa_sign_s,
+                                  pa_msg, msgLenArr,
+                                  (const ed25519_public_key**)pa_public_key);
+
+    ret = MBX_STATUS_OK == sts ? 1 : 0;
+
+    data->sigver_success = 1;
+    if(!ret){
+        data->sigver_success = 0;
+    }
+
+out:
+    free(msg);
+    free(public_key);
+
+    return ret;
+}
+
+static struct eddsa_backend cryptomb_eddsa =
+{
+	cryptomb_eddsa_keygen,
+	NULL, // eddsa_keyver,
+	cryptomb_eddsa_siggen,
+	cryptomb_eddsa_sigver,
+    cryptomb_eddsa_keygen_en,
+	cryptomb_eddsa_free_key
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_eddsa_backend)
+static void cryptomb_eddsa_backend(void)
+{
+	register_eddsa_impl(&cryptomb_eddsa);
+}
+
+/************************************************
+ * RSA pub exponent testing - OAEP KTS
+ ************************************************/
+static int cryptomb_rsa_kas_ifc_encrypt_common(struct kts_ifc_data *data, uint32_t *validation_success)
+{
+    (void)validation_success;
+
+    int ret = 0;
+    mbx_status sts = MBX_STATUS_OK;
+
+    struct kts_ifc_init_data *init = &data->u.kts_ifc_init;
+
+    int keyBitlen = data->keylen;
+    int modBytelen = data->modulus >> 3;
+
+	struct buffer *dkm_p, *c_p;
+
+    left_pad_buf(&init->n, modBytelen);
+    if (!init->dkm.len) {
+        alloc_buf(keyBitlen >> 3, &init->dkm);
+        RAND_bytes(init->dkm.buf, (int)init->dkm.len);
+
+        /*
+        * Ensure that in case of raw encryption, the value is
+        * not too large.
+        */
+        init->dkm.buf[0] &= ~0x80;
+    }
+    dkm_p = &init->dkm;
+    c_p = &init->iut_c;
+
+    /* output ciphertext */
+    int8u out_ciphertext[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN];
+    int8u *pa_ciphertext[MBX_NUM_BUFFERS] = {
+        out_ciphertext[0], out_ciphertext[1], out_ciphertext[2], out_ciphertext[3],
+        out_ciphertext[4], out_ciphertext[5], out_ciphertext[6], out_ciphertext[7]};
+
+    // plaintext
+    const int8u *pa_plaintext[MBX_NUM_BUFFERS] = {
+        dkm_p->buf, dkm_p->buf, dkm_p->buf, dkm_p->buf,
+        dkm_p->buf, dkm_p->buf, dkm_p->buf, dkm_p->buf};
+
+    // moduli
+    int8u* pN = malloc(init->n.len);
+    dataReverse(pN, (const char*)init->n.buf, init->n.len);
+    const int64u *pa_moduli[MBX_NUM_BUFFERS] = {
+        (int64u *)pN, (int64u *)pN, (int64u *)pN, (int64u *)pN,
+        (int64u *)pN, (int64u *)pN, (int64u *)pN, (int64u *)pN};
+
+    const mbx_RSA_Method* method = mbx_RSA_pub65537_Method(data->modulus);
+
+    // oaep encoding
+        int8u  seedMask[32] = {0};
+        int hashLen = 32;
+        int k = modBytelen;
+        int srcLen = dkm_p->len;
+        int8u* pSrc = dkm_p->buf;
+
+        int8u* pMaskedSeed = (int8u*)out_ciphertext[0]+1;
+        int8u* pMaskedDB = (int8u*)out_ciphertext[0] +hashLen +1;
+
+        out_ciphertext[0][0] = 0;
+        const IppsHashMethod* pMethod = ippsHashMethod_SHA256();
+
+        /* maskedDB = MGF(seed, k-1-hashLen)*/
+        ippsMGF1_rmf(pSeed, hashLen, pMaskedDB, k-1-hashLen, pMethod);
+
+        /* seedMask = HASH(pLab) */
+        ippsHashMessage_rmf(NULL, 0, seedMask, pMethod);
+
+        /* maskedDB ^= concat(HASH(pLab),PS,0x01,pSc) */
+        XorBlock(pMaskedDB, seedMask, pMaskedDB, hashLen);
+        pMaskedDB[k-srcLen-hashLen-2] ^= 0x01;
+        XorBlock(pMaskedDB+k-srcLen-hashLen-2+1, pSrc, pMaskedDB+k-srcLen-hashLen-2+1, srcLen);
+
+        /* seedMask = MGF(maskedDB, hashLen) */
+        ippsMGF1_rmf(pMaskedDB, k-1-hashLen, seedMask, hashLen, pMethod);
+        /* maskedSeed = seed ^ seedMask */
+        XorBlock(pSeed, seedMask, pMaskedSeed, hashLen);
+
+    sts = mbx_rsa_public_mb8(pa_ciphertext, pa_ciphertext, pa_moduli, data->modulus, method, NULL);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_rsa_public_mb8\n")
+
+	alloc_buf(modBytelen, c_p);
+    memcpy(c_p->buf, pa_ciphertext[0], modBytelen);
+
+out:
+   free(pN);
+
+    return ret;
+}
+
+static int cryptomb_kts_ifc_generate(struct kts_ifc_data *data, flags_t parsed_flags)
+{
+	int ret = 0;
+    (void)data; (void)parsed_flags;
+    if ((parsed_flags & FLAG_OP_KAS_ROLE_INITIATOR) &&
+	    (parsed_flags & FLAG_OP_AFT)) {
+		cryptomb_rsa_kas_ifc_encrypt_common(data, NULL);
+    }
+    else {
+        logger(LOGGER_ERR, "Unsupported test, only public exponent is tested with KTS.\n");
+        logger(LOGGER_ERR, "For private exponent test please use rsa_backend and rsa decryption primitive testing\n");
+        ret = -1;
+    }
+
+	return ret;
+}
+
+static struct kts_ifc_backend cryptomb_kts_ifc =
+{
+	cryptomb_kts_ifc_generate,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_kts_ifc_backend)
+static void cryptomb_kts_ifc_backend(void)
+{
+	register_kts_ifc_impl(&cryptomb_kts_ifc);
+}
+
+/****************************************************
+ * RSA priv exponent testing - rsa decrypt privitive
+ ****************************************************/
+static int cryptomb_rsa_keygen_en(struct buffer *ebuf, uint32_t modulus, void **privkey, struct buffer *nbuf) {
+    int ret = 0;
+
+	BIGNUM *egen = BN_new();
+    BIGNUM *n = BN_new();
+	EVP_PKEY *rsa = EVP_PKEY_new();
+
+    int64u e = 65537;
+    BIGNUM* bn_e = BN_new();
+    BN_set_word(bn_e, e);
+
+    int rsaBitsize = modulus;
+
+    ret = openssl_generate_rsa_key(rsa, bn_e, rsaBitsize);
+    CKNULL_LOG((ret == 1), ret, "Error in openssl_generate_rsa_key")
+
+    EVP_PKEY_get_bn_param(rsa, "n", &n);
+    EVP_PKEY_get_bn_param(rsa, "e", &egen);
+
+    /* Store n and e in output buffers */
+    alloc_buf(BN_num_bytes(egen), ebuf);
+	BN_bn2binpad(egen, ebuf->buf, BN_num_bytes(egen));
+    alloc_buf(BN_num_bytes(n), nbuf);
+    BN_bn2binpad(n, nbuf->buf, BN_num_bytes(n));
+
+    *privkey = rsa;
+
+out:
+    BN_free(bn_e);
+    BN_free(egen);
+    BN_free(n);
+
+	return ret;
+}
+
+static void cryptomb_rsa_free_key(void *privkey)
+{
+	EVP_PKEY *rsa = (EVP_PKEY *)privkey;
+
+	if (rsa)
+		EVP_PKEY_free(rsa);
+}
+
+static int
+cryptomb_rsa_decryption_primitive(struct rsa_decryption_primitive_data *data, flags_t parsed_flags)
+{
+	int ret = 1;
+    mbx_status sts = MBX_STATUS_OK;
+	(void)parsed_flags;
+
+    /* Define RSA bitlen */
+    int rsaByteLen = data->n.len;
+    int rsaBitsize = rsaByteLen*8;
+
+    /* Set RSA method */
+    const mbx_RSA_Method* rsaMethodPrv = mbx_RSA_private_Method(rsaBitsize);
+    const mbx_RSA_Method* rsaMethodPrvCrt = mbx_RSA_private_crt_Method(rsaBitsize);
+
+    int8u* rsaBufferPrv = malloc(mbx_RSA_Method_BufSize(rsaMethodPrv));
+    int8u* rsaBufferPrvCrt = malloc(mbx_RSA_Method_BufSize(rsaMethodPrvCrt));
+
+    /* output plaintext - allocate maximum possible buffer */
+    int8u out_plaintext_basic[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN] = {0};
+    int8u *pa_plaintext_basic[MBX_NUM_BUFFERS] = {
+        out_plaintext_basic[0], out_plaintext_basic[1], out_plaintext_basic[2], out_plaintext_basic[3],
+        out_plaintext_basic[4], out_plaintext_basic[5], out_plaintext_basic[6], out_plaintext_basic[7]};
+    int8u out_plaintext_crt[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN] = {0};
+    int8u *pa_plaintext_crt[MBX_NUM_BUFFERS] = {
+        out_plaintext_crt[0], out_plaintext_crt[1], out_plaintext_crt[2], out_plaintext_crt[3],
+        out_plaintext_crt[4], out_plaintext_crt[5], out_plaintext_crt[6], out_plaintext_crt[7]};
+    /* input ciphertext  */
+    int8u msg_buff[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN];
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++){
+        memcpy(msg_buff[i], (const char*)data->msg.buf, data->msg.len);
+    }
+    int8u *pa_ciphertext[MBX_NUM_BUFFERS] = {
+        msg_buff[0], msg_buff[1], msg_buff[2], msg_buff[3],
+        msg_buff[4], msg_buff[5], msg_buff[6], msg_buff[7] };
+
+    /* classic parameters */
+    // private exponent and moduli
+    int64u d_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64] = {0};
+    int64u e_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64] = {0};
+    int64u n_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64] = {0};
+    const int64u *pa_d[MBX_NUM_BUFFERS] = {
+        d_buff[0], d_buff[1], d_buff[2], d_buff[3],
+        d_buff[4], d_buff[5], d_buff[6], d_buff[7],
+    };
+    const int64u *pa_e[MBX_NUM_BUFFERS] = {
+        e_buff[0], e_buff[1], e_buff[2], e_buff[3],
+        e_buff[4], e_buff[5], e_buff[6], e_buff[7],
+    };
+    const int64u *pa_moduli[MBX_NUM_BUFFERS] = {
+        n_buff[0], n_buff[1], n_buff[2], n_buff[3],
+        n_buff[4], n_buff[5], n_buff[6], n_buff[7],
+    };
+
+    /* CRT parameters */
+    // p, q primes and their CRT private exponent
+    int64u p_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64 / 2] = {0};
+    int64u q_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64 / 2] = {0};
+    int64u dp_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64 / 2] = {0};
+    int64u dq_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64 / 2] = {0};
+    int64u iq_buff[MBX_NUM_BUFFERS][RSA_MAX_LEN64 / 2] = {0};
+    const int64u *pa_p[MBX_NUM_BUFFERS] = {
+        p_buff[0], p_buff[1], p_buff[2], p_buff[3],
+        p_buff[4], p_buff[5], p_buff[6], p_buff[7],
+    };
+    const int64u *pa_q[MBX_NUM_BUFFERS] = {
+        q_buff[0], q_buff[1], q_buff[2], q_buff[3],
+        q_buff[4], q_buff[5], q_buff[6], q_buff[7],
+    };
+    const int64u *pa_dp[MBX_NUM_BUFFERS] = {
+        dp_buff[0], dp_buff[1], dp_buff[2], dp_buff[3],
+        dp_buff[4], dp_buff[5], dp_buff[6], dp_buff[7],
+    };
+    const int64u *pa_dq[MBX_NUM_BUFFERS] = {
+        dq_buff[0], dq_buff[1], dq_buff[2], dq_buff[3],
+        dq_buff[4], dq_buff[5], dq_buff[6], dq_buff[7],
+    };
+    /* CRT coefficient */
+    const int64u *pa_inv_q[MBX_NUM_BUFFERS] = {
+        iq_buff[0], iq_buff[1], iq_buff[2], iq_buff[3],
+        iq_buff[4], iq_buff[5], iq_buff[6], iq_buff[7],
+    };
+
+    /* Get RSA key info */
+	EVP_PKEY *rsa = data->privkey;
+
+    /* Get bignum components */
+    BIGNUM *bn_n = BN_new();
+    BIGNUM *bn_e = BN_new();
+    BIGNUM *bn_d = BN_new();
+    BIGNUM *bn_p = BN_new();
+    BIGNUM *bn_q = BN_new();
+    BIGNUM *bn_dp = BN_new();
+    BIGNUM *bn_dq = BN_new();
+    BIGNUM *bn_qinvp = BN_new();
+    EVP_PKEY_get_bn_param(rsa, "n", &bn_n);
+    EVP_PKEY_get_bn_param(rsa, "e", &bn_e);
+    EVP_PKEY_get_bn_param(rsa, "d", &bn_d);
+    EVP_PKEY_get_bn_param(rsa, "rsa-factor1", &bn_p);
+    EVP_PKEY_get_bn_param(rsa, "rsa-factor2", &bn_q);
+    EVP_PKEY_get_bn_param(rsa, "rsa-exponent1", &bn_dp);
+    EVP_PKEY_get_bn_param(rsa, "rsa-exponent2", &bn_dq);
+    EVP_PKEY_get_bn_param(rsa, "rsa-coefficient1", &bn_qinvp);
+
+    /* Convert bignumms to strings */
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        BN_bn2bin(bn_d, (int8u*)(pa_d[i]));
+        wsp_str((int8u*)(pa_d[i]), BN_num_bytes(bn_d));
+        BN_bn2bin(bn_n, (int8u*)(pa_moduli[i]));
+        wsp_str((int8u*)(pa_moduli[i]), BN_num_bytes(bn_n));
+
+        BN_bn2bin(bn_e, (int8u*)(pa_e[i]));
+        wsp_str((int8u*)(pa_e[i]), BN_num_bytes(bn_e));
+
+        BN_bn2bin(bn_p, (int8u*)(pa_p[i]));
+        wsp_str((int8u*)(pa_p[i]), BN_num_bytes(bn_p));
+        BN_bn2bin(bn_q, (int8u*)(pa_q[i]));
+        wsp_str((int8u*)(pa_q[i]), BN_num_bytes(bn_q));
+        BN_bn2bin(bn_dp, (int8u*)(pa_dp[i]));
+        wsp_str((int8u*)(pa_dp[i]), BN_num_bytes(bn_dp));
+        BN_bn2bin(bn_dq, (int8u*)(pa_dq[i]));
+        wsp_str((int8u*)(pa_dq[i]), BN_num_bytes(bn_dq));
+        BN_bn2bin(bn_qinvp, (int8u*)(pa_inv_q[i]));
+        wsp_str((int8u*)(pa_inv_q[i]), BN_num_bytes(bn_qinvp));
+    }
+
+    data->dec_result = 1;
+
+    /* Check message and generated modulus */
+    BIGNUM *bn_msg = BN_new();
+    BN_bin2bn(data->msg.buf, data->msg.len, bn_msg);
+    int cmp_bn_res = BN_cmp(bn_msg, bn_n);
+    if(cmp_bn_res == 1){
+        logger(LOGGER_WARN, "Error, message is bigger than modulus\n");
+        data->dec_result = 0;
+        goto out;
+    }
+
+    sts = mbx_rsa_private_crt_mb8(pa_ciphertext, pa_plaintext_crt, pa_p, pa_q,
+                                  pa_dp, pa_dq, pa_inv_q, rsaBitsize,
+                                  rsaMethodPrvCrt, rsaBufferPrvCrt);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_rsa_private_crt_mb8")
+
+    sts = mbx_rsa_private_mb8(pa_ciphertext, pa_plaintext_basic,
+                            (const int64u **)pa_d,
+                            (const int64u **)pa_moduli,
+                            rsaBitsize,
+                            rsaMethodPrv, rsaBufferPrv);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_rsa_private_mb8")
+
+    /* Check the output */
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        int cmp_flag = memcmp(pa_plaintext_basic[i], pa_plaintext_basic[0], rsaByteLen);
+        if(cmp_flag){
+			logger(LOGGER_ERR, "Different output in buffers, the result is unexpected\n");
+            ret = -1;
+            break;
+        }
+        cmp_flag = memcmp(pa_plaintext_crt[i], pa_plaintext_basic[i], rsaByteLen);
+        if(cmp_flag){
+			logger(LOGGER_ERR, "Different output between crt and basic decryption\n");
+            ret = -1;
+            break;
+        }
+    }
+
+    if(!ret) {
+        data->dec_result = 0;
+    }
+    else{
+        alloc_buf(rsaByteLen, &data->s);
+        memcpy(data->s.buf, pa_plaintext_basic[0], rsaByteLen);
+    }
+
+out:
+    BN_free(bn_n);
+    BN_free(bn_e);
+    BN_free(bn_d);
+    BN_free(bn_p);
+    BN_free(bn_q);
+    BN_free(bn_dp);
+    BN_free(bn_dq);
+    BN_free(bn_qinvp);
+
+    BN_free(bn_msg);
+
+    free(rsaBufferPrv);
+    free(rsaBufferPrvCrt);
+
+    return ret;
+}
+
+static struct rsa_backend cryptomb_rsa =
+{
+	NULL, /* rsa_keygen */
+	NULL, /* rsa_siggen */
+	NULL, /* rsa_sigver */
+	NULL, /* rsa_keygen_prime */
+	NULL, /* rsa_keygen_prov_prime */
+	cryptomb_rsa_keygen_en,
+	cryptomb_rsa_free_key,
+	NULL,
+	cryptomb_rsa_decryption_primitive,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_rsa_backend)
+static void cryptomb_rsa_backend(void)
+{
+	register_rsa_impl(&cryptomb_rsa);
+}

--- a/backends/backend_cryptomb_common.h
+++ b/backends/backend_cryptomb_common.h
@@ -1,0 +1,392 @@
+/*************************************************************************
+* Copyright (C) 2024 Intel Corporation
+*
+* Licensed under the Apache License,  Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* 	http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law  or agreed  to  in  writing,  software
+* distributed under  the License  is  distributed  on  an  "AS IS"  BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the  specific  language  governing  permissions  and
+* limitations under the License.
+*************************************************************************/
+
+#ifndef _CRYPTOMB_COMMON_H
+#define _CRYPTOMB_COMMON_H
+
+#include <strings.h>
+#include <ctype.h>
+
+#include <openssl/bn.h>
+#include <openssl/rand.h>
+#include <openssl/ec.h>
+#include <openssl/obj_mac.h>
+#include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+
+#include <crypto_mb/ec_nistp256.h>
+#include <crypto_mb/ec_nistp384.h>
+#include <crypto_mb/ec_nistp521.h>
+#include <crypto_mb/ed25519.h>
+#include <crypto_mb/rsa.h>
+
+#include <ippcp.h>
+
+#include "backend_common.h"
+
+#define NUM_OF_DIGS(bitsize, digsize)   (((bitsize) + (digsize)-1)/(digsize))
+
+#define GF256_BITLEN (256)
+#define GF384_BITLEN (384)
+#define GF521_BITLEN (521)
+
+// data in residual (2^64) domain
+#define GF256_LEN64 (NUM_OF_DIGS(GF256_BITLEN, 64))
+#define GF256_LEN8  (NUM_OF_DIGS(GF256_BITLEN, 8))
+
+#define GF384_LEN64 (NUM_OF_DIGS(GF384_BITLEN, 64))
+#define GF384_LEN8  (NUM_OF_DIGS(GF384_BITLEN, 8))
+
+#define GF521_LEN64 (NUM_OF_DIGS(GF521_BITLEN, 64))
+#define GF521_LEN8  (NUM_OF_DIGS(GF521_BITLEN, 8))
+
+#define MAX_LEN64 GF521_LEN64
+#define MAX_LEN8  GF521_LEN8
+
+// macroses for buffers allocat9ion
+// use to reduce repeatable code lines number
+#define create_mbx_buffer_int64u(name) \
+    __ALIGN64 int64u name[8][MAX_LEN64]; \
+    int64u* pa_##name[8] = {name[0], name[1], name[2], name[3], name[4], name[5], name[6], name[7]};
+
+#define create_mbx_buffer_int8u(name) \
+    __ALIGN64 int8u name[8][MAX_LEN8]; \
+    int8u* pa_##name[8] = {name[0], name[1], name[2], name[3], name[4], name[5], name[6], name[7]};
+
+#define create_and_clean_mbx_buffer_int64u(name) \
+    create_mbx_buffer_int64u(name) \
+    memset(name, 0, sizeof(name));
+
+#define create_and_clean_mbx_buffer_int8u(name) \
+    create_mbx_buffer_int8u(name) \
+    memset(name, 0, sizeof(name));
+
+/************************************************
+ * ECDSA interface functions
+ ************************************************/
+#define MBX_ALIGNMENT   (8)
+#define MBX_NUM_BUFFERS (8)
+
+typedef enum {
+    nistp256,
+    nistp384,
+    nistp521,
+    ec_unset
+} ec_type;
+
+#define maxMsgDigestSize (67)
+#define maxSize64u       ((maxMsgDigestSize + 7)/8)
+
+static int8u* reverse_bytes(int8u* out, const int8u* inp, int len)
+{
+    if (out == inp) { // inplace
+        for (int i = 0; i < len / 2; i++) {
+            int8u a = inp[i];
+            out[i] = inp[len - 1 - i];
+            out[len - 1 - i] = a;
+        }
+    }
+    else { // not inplace
+        for (int i = 0; i < len; i++) {
+            out[i] = inp[len - 1 - i];
+        }
+    }
+    return out;
+}
+
+
+/* Stuff functions */
+static BIGNUM* set_BN_data(BIGNUM* bn, const int64u x[], const int len8)
+{
+    int8u* tmp = malloc(len8);
+    reverse_bytes(tmp, (int8u*)x, len8);
+    BN_bin2bn(tmp, len8, bn);
+    free(tmp);
+    return bn;
+}
+
+static int64u* get_BN_data(int64u x[], const BIGNUM* bn, const int len64)
+{
+    // clear buffer
+    memset(x, 0, sizeof(int64u) * len64);
+    int num_bytes = BN_num_bytes(bn);
+
+    BN_bn2bin(bn, (int8u*)x);
+    reverse_bytes((int8u*)x, (int8u*)x, num_bytes);
+
+    return x;
+}
+
+typedef enum {
+    affine_coords,
+    projective_coords
+} coords_type;
+
+/* Produce OpenSSL public and private keys and return BIGNUMs */
+static EVP_PKEY* openssl_generate_keys_bn(BIGNUM* priv_key, BIGNUM* pubx_key, BIGNUM* puby_key, BIGNUM* pubz_key, EC_GROUP* EC, const char *curvename, int len8, coords_type coords)
+{
+    (void)pubz_key; (void)coords;
+    EVP_PKEY* keyA = NULL;
+    BN_CTX* ctx = BN_CTX_new();
+
+#if OPENSSL_VERSION_MAJOR >= 3
+    EVP_PKEY_CTX *evp_ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+    EVP_PKEY_keygen_init(evp_ctx);
+    EVP_PKEY_CTX_set_group_name(evp_ctx, (char *)curvename);
+
+    // Generate key pairs
+    EVP_PKEY_generate(evp_ctx, &keyA);
+
+    // Set the point conversion format as compressed in order to apply changes from 3.0.8 version
+    OSSL_PARAM params[2];
+    params[0] = OSSL_PARAM_construct_utf8_string("point-format",(char*)"compressed", 0);
+    params[1] = OSSL_PARAM_construct_end();
+    EVP_PKEY_set_params(keyA, params);
+
+    // We don't need private key for verification
+    if (priv_key != NULL) {
+        // extract private keys and store
+        BIGNUM *tmp_out = NULL;
+        EVP_PKEY_get_bn_param(keyA, "priv", &tmp_out);
+        BN_copy(priv_key, tmp_out);
+    }
+
+    // We don't need public key for signature
+    if (pubx_key != NULL && puby_key != NULL) {
+        // extract public key and store it affine coordinates (OpenSSL3.0 doesn't support projective coordinates)
+        unsigned char* out_pubkey = (unsigned char* )malloc(len8 + 1);
+        size_t out_pubkey_len = 0;
+        EC_POINT* tmp_point = EC_POINT_new(EC);
+        EVP_PKEY_get_octet_string_param(keyA, "pub", out_pubkey, len8 + 1, &out_pubkey_len);
+        EC_POINT_oct2point(EC, tmp_point, out_pubkey, out_pubkey_len, ctx);
+        EC_POINT_get_affine_coordinates(EC, tmp_point, pubx_key, puby_key, ctx);
+        EC_POINT_free(tmp_point);
+        free(out_pubkey);
+    }
+
+    // release resources
+    EVP_PKEY_CTX_free(evp_ctx);
+#else
+    keyA = NEW_OPENSSL_KEY();
+    EC_KEY_set_group(keyA, EC);
+    EC_KEY_generate_key(keyA);
+
+    // We don't need private key for verification
+    if (priv_key != NULL) {
+        // extract private keys and store
+        BN_copy(priv_key, EC_KEY_get0_private_key(keyA));
+    }
+
+    // We don't need public key for signature
+    if (pubx_key != NULL && puby_key != NULL) {
+        // extract public key and store it projective/affine coordinates
+        if (coords == coords_type::projective_coords) {
+#if !defined(OPENSSL_IS_BORINGSSL)
+            EC_POINT_get_Jprojective_coordinates_GFp(EC, EC_KEY_get0_public_key(keyA), pubx_key, puby_key, pubz_key, ctx);
+
+#endif
+        }
+        else
+            EC_POINT_get_affine_coordinates_GFp(EC, EC_KEY_get0_public_key(keyA), pubx_key, puby_key, ctx);
+    }
+#endif
+
+    // release resources
+    BN_CTX_free(ctx);
+    return keyA;
+}
+
+/* Produce OpenSSL public and private keys and return data*/
+static EVP_PKEY* openssl_generate_keys(int64u* priv_key, int64u* pubx_key, int64u* puby_key, int64u* pubz_key, EC_GROUP* EC, const char *curvename, int len8, int len64, coords_type coords)
+{
+    (void)pubz_key;
+    EVP_PKEY* keyA = NULL;
+
+    BIGNUM* bn_priv_key = BN_new();
+    BIGNUM* bn_pubx_key = BN_new();
+    BIGNUM* bn_puby_key = BN_new();
+    BIGNUM* bn_pubz_key = BN_new();
+
+    keyA = openssl_generate_keys_bn(bn_priv_key, bn_pubx_key, bn_puby_key, bn_pubz_key, EC, curvename, len8, coords);
+
+#if OPENSSL_VERSION_MAJOR >= 3
+    // We don't need private key for verification
+    if (priv_key != NULL) {
+        // extract private keys and store
+        get_BN_data(priv_key, bn_priv_key, len64);
+    }
+
+    // We don't need public key for signature
+    if (pubx_key != NULL && puby_key != NULL) {
+        get_BN_data(pubx_key, bn_pubx_key, len64);
+        get_BN_data(puby_key, bn_puby_key, len64);
+    }
+#else
+    // We don't need private key for verification
+    if (priv_key != NULL) {
+        // extract private keys and store
+        get_BN_data(priv_key, bn_priv_key, len64);
+    }
+
+    // We don't need public key for signature
+    if (pubx_key != NULL && puby_key != NULL) {
+        // extract public key and store it projective/affine coordinates
+        if (coords == coords_type::projective_coords) {
+#if !defined(OPENSSL_IS_BORINGSSL)
+            get_BN_data(pubx_key, bn_pubx_key, len64);
+            get_BN_data(puby_key, bn_puby_key, len64);
+            get_BN_data(pubz_key, bn_pubz_key, len64);
+#endif
+        }
+        else {
+            get_BN_data(pubx_key, bn_pubx_key, len64);
+            get_BN_data(puby_key, bn_puby_key, len64);
+        }
+    }
+#endif
+
+    // release resources
+    BN_free(bn_priv_key);
+    BN_free(bn_pubx_key);
+    BN_free(bn_puby_key);
+    BN_free(bn_pubz_key);
+
+    return keyA;
+}
+
+static ECDSA_SIG* openssl_generate_signature(int8u* msg_buffer, int msg_byte_size, EVP_PKEY* key)
+{
+    ECDSA_SIG* sign = 0;
+    (void)key;
+
+    EVP_PKEY_CTX *sign_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+    EVP_PKEY_sign_init(sign_ctx);
+
+    // Calculate sign's size
+    size_t sig_len;
+    EVP_PKEY_sign(sign_ctx, NULL, &sig_len, msg_buffer, msg_byte_size);
+
+    unsigned char *sig = malloc(sig_len);
+    EVP_PKEY_sign(sign_ctx, sig, &sig_len, msg_buffer, msg_byte_size);
+
+    const unsigned char * p = sig;
+    sign = d2i_ECDSA_SIG(NULL, &p, (long)sig_len);
+    // free
+    EVP_PKEY_CTX_free(sign_ctx);
+    free(sig);
+
+    return sign;
+}
+
+/* Restore ephemeral private key to BIGNUM */
+void openssl_restore_eph_key_bn(BIGNUM** eph_key, BIGNUM* priv_key, const BIGNUM* signR, const BIGNUM* signS, BIGNUM* bn_msg, EC_GROUP* EC) {
+    // get order
+    BIGNUM *order = BN_new();
+    EC_GROUP_get_order(EC, order, 0);
+    BN_CTX *bn_ctx = BN_CTX_new();
+
+    BIGNUM* tmp_1 = BN_new();
+    BIGNUM* tmp_2 = BN_new();
+
+    BN_mod_mul(tmp_1, priv_key, signR, order, bn_ctx);
+    BN_mod_add(tmp_1, tmp_1, bn_msg, order, bn_ctx);
+
+    BN_mod_inverse(tmp_2, signS, order, bn_ctx);
+    BN_mod_mul(*eph_key, tmp_1, tmp_2, order, bn_ctx);
+
+    BN_free(tmp_1);
+    BN_free(tmp_2);
+
+    BN_CTX_free(bn_ctx);
+    BN_free(order);
+}
+
+/* Restore ephemeral private key */
+void openssl_restore_eph_key(int64u* eph_key, int64u* priv_key, const BIGNUM* signR, const BIGNUM* signS, BIGNUM* bn_msg, int len8, int len64, EC_GROUP* EC) {
+
+    BIGNUM* bn_k = BN_new();
+    BIGNUM* bn_priv_key = BN_new();
+
+    set_BN_data(bn_priv_key, priv_key, len8);
+    openssl_restore_eph_key_bn(&bn_k, bn_priv_key, signR, signS, bn_msg, EC);
+    get_BN_data(eph_key, bn_k, len64);
+
+    // free
+    BN_free(bn_k);
+    BN_free(bn_priv_key);
+}
+
+/***********************************************************
+ * RSA priv and pub exponents testing - rsa decrypt privitive
+ ***********************************************************/
+#define MBX_RSA2K_DATA_BIT_LEN (2048)
+#define MBX_RSA2K_DATA_BYTE_LEN ( (MBX_RSA2K_DATA_BIT_LEN) >> 3 )
+
+#define MBX_RSA4K_DATA_BIT_LEN (4096)
+#define MBX_RSA4K_DATA_BYTE_LEN ( (MBX_RSA4K_DATA_BIT_LEN) >> 3 )
+
+#define NUM_OF_DIGS(bitsize, digsize)   (((bitsize) + (digsize)-1)/(digsize))
+#define RSA_MAX_LEN64 (NUM_OF_DIGS(MBX_RSA4K_DATA_BIT_LEN, 64))
+
+
+static void dataReverse(int8u* pBuf, const char* str, int size) {
+    for(int i=0;i<size;i++){
+        pBuf[i] = str[size-i-1];
+    }
+}
+
+static int8u* wsp_str(int8u* tofrom, int len)
+{
+    int i;
+    for (i = 0; i < len / 2; i++) {
+        int8u x = tofrom[i];
+        tofrom[i] = tofrom[len - 1 - i];
+        tofrom[len - 1 - i] = x;
+    }
+    return tofrom;
+}
+
+/* Generate OpenSSL RSA key */
+static int openssl_generate_rsa_key(EVP_PKEY* rsa, BIGNUM* bn_e, unsigned int rsaBitsize) {
+    int ret = 1;
+
+    EVP_PKEY_CTX * pctx = EVP_PKEY_CTX_new_from_name(NULL, "rsa", NULL);
+    ret = EVP_PKEY_keygen_init(pctx);
+    ret = EVP_PKEY_CTX_set_rsa_keygen_bits(pctx, rsaBitsize) & ret;
+    ret = EVP_PKEY_CTX_set1_rsa_keygen_pubexp(pctx, bn_e) & ret;
+    ret = EVP_PKEY_keygen(pctx, &rsa) & ret;
+
+    return ret;
+}
+
+__attribute__((aligned(64))) static const int8u pSeed[]  = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                                                           "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                                                           "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                                                           "\x00\x00";
+
+/* XOR block */
+__INLINE void XorBlock(const void* pSrc1, const void* pSrc2, void* pDst, int len)
+{
+   const Ipp8u* p1 = (const Ipp8u*)pSrc1;
+   const Ipp8u* p2 = (const Ipp8u*)pSrc2;
+   Ipp8u* d  = (Ipp8u*)pDst;
+   int k;
+   for(k=0; k<len; k++)
+      d[k] = (Ipp8u)(p1[k] ^p2[k]);
+}
+
+#endif //_CRYPTOMB_COMMON_H

--- a/backends/backend_cryptombssl.c
+++ b/backends/backend_cryptombssl.c
@@ -1,0 +1,902 @@
+/*************************************************************************
+* Copyright (C) 2024 Intel Corporation
+*
+* Licensed under the Apache License,  Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* 	http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law  or agreed  to  in  writing,  software
+* distributed under  the License  is  distributed  on  an  "AS IS"  BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the  specific  language  governing  permissions  and
+* limitations under the License.
+*************************************************************************/
+
+#include <strings.h>
+#include <ctype.h>
+
+#include "backend_common.h"
+#include "backend_cryptomb_common.h"
+
+/************************************************
+ * ECDSA interface functions - SSL API
+ ************************************************/
+static int len64, len8, msglen;
+
+// globals (group)
+static EC_GROUP* EC = NULL;
+static const char *curvename;
+
+/************************************************
+ * ECDSA interface functions - SSL verdion
+ ************************************************/
+typedef mbx_status (*p_mbx_nistp_ecpublic_key_ssl_mb8)(BIGNUM**, BIGNUM**, BIGNUM**, const BIGNUM** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_sign_ssl_mb8)(int8u**, int8u**, const int8u** const, const BIGNUM** const, const BIGNUM** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_sign_ssl_setup_mb8)(BIGNUM**, BIGNUM**, const BIGNUM** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_sign_ssl_complete_mb8)(int8u**, int8u**, const int8u** const, const BIGNUM** const, const BIGNUM** const, const BIGNUM** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdsa_verify_ssl_mb8)(const ECDSA_SIG** const, const int8u** const, const BIGNUM** const, const BIGNUM** const, const BIGNUM** const, int8u*);
+typedef mbx_status (*p_mbx_nistp_ecdh_ssl_mb8)(int8u**, const BIGNUM** const, const BIGNUM** const, const BIGNUM** const, const BIGNUM** const, int8u*);
+
+static p_mbx_nistp_ecpublic_key_ssl_mb8 mbx_nistp_ecpublic_key_ssl_mb8 = NULL;
+static p_mbx_nistp_ecdsa_sign_ssl_mb8 mbx_nistp_ecdsa_sign_ssl_mb8 = NULL;
+static p_mbx_nistp_ecdsa_sign_ssl_setup_mb8 mbx_nistp_ecdsa_sign_setup_ssl_mb8 = NULL;
+static p_mbx_nistp_ecdsa_sign_ssl_complete_mb8 mbx_nistp_ecdsa_sign_complete_ssl_mb8 = NULL;
+static p_mbx_nistp_ecdsa_verify_ssl_mb8 mbx_nistp_ecdsa_verify_ssl_mb8 = NULL;
+static p_mbx_nistp_ecdh_ssl_mb8 mbx_nistp_ecdh_ssl_mb8 = NULL;
+
+static void set_ec_ssl_params(ec_type ec)
+{
+    switch (ec)
+    {
+    case nistp256:
+        EC = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1);
+        len8  = GF256_LEN8;
+        curvename = "P-256";
+        mbx_nistp_ecpublic_key_ssl_mb8 = mbx_nistp256_ecpublic_key_ssl_mb8;
+        mbx_nistp_ecdsa_sign_ssl_mb8 = mbx_nistp256_ecdsa_sign_ssl_mb8;
+        mbx_nistp_ecdsa_sign_setup_ssl_mb8 = mbx_nistp256_ecdsa_sign_setup_ssl_mb8;
+        mbx_nistp_ecdsa_sign_complete_ssl_mb8 = mbx_nistp256_ecdsa_sign_complete_ssl_mb8;
+        mbx_nistp_ecdsa_verify_ssl_mb8 = mbx_nistp256_ecdsa_verify_ssl_mb8;
+        mbx_nistp_ecdh_ssl_mb8 = mbx_nistp256_ecdh_ssl_mb8;
+        msglen = GF256_BITLEN;
+        break;
+    case nistp384:
+        EC = EC_GROUP_new_by_curve_name(NID_secp384r1);
+        len8  = GF384_LEN8;
+        curvename = "P-384";
+        mbx_nistp_ecpublic_key_ssl_mb8 = mbx_nistp384_ecpublic_key_ssl_mb8;
+        mbx_nistp_ecdsa_sign_ssl_mb8 = mbx_nistp384_ecdsa_sign_ssl_mb8;
+        mbx_nistp_ecdsa_sign_setup_ssl_mb8 = mbx_nistp384_ecdsa_sign_setup_ssl_mb8;
+        mbx_nistp_ecdsa_sign_complete_ssl_mb8 = mbx_nistp384_ecdsa_sign_complete_ssl_mb8;
+        mbx_nistp_ecdsa_verify_ssl_mb8 = mbx_nistp384_ecdsa_verify_ssl_mb8;
+        mbx_nistp_ecdh_ssl_mb8 = mbx_nistp384_ecdh_ssl_mb8;
+        msglen = GF384_BITLEN;
+        break;
+    case nistp521:
+        EC = EC_GROUP_new_by_curve_name(NID_secp521r1);
+        len8  = GF521_LEN8;
+        curvename = "P-521";
+        mbx_nistp_ecpublic_key_ssl_mb8 = mbx_nistp521_ecpublic_key_ssl_mb8;
+        mbx_nistp_ecdsa_sign_ssl_mb8 = mbx_nistp521_ecdsa_sign_ssl_mb8;
+        mbx_nistp_ecdsa_sign_setup_ssl_mb8 = mbx_nistp521_ecdsa_sign_setup_ssl_mb8;
+        mbx_nistp_ecdsa_sign_complete_ssl_mb8 = mbx_nistp521_ecdsa_sign_complete_ssl_mb8;
+        mbx_nistp_ecdsa_verify_ssl_mb8 = mbx_nistp521_ecdsa_verify_ssl_mb8;
+        mbx_nistp_ecdh_ssl_mb8 = mbx_nistp521_ecdh_ssl_mb8;
+        // length of msg must be mutiple 8 (OpenSSL specific)
+        msglen = GF521_BITLEN - (GF521_BITLEN % 8);
+        break;
+    default:
+        break;
+    }
+}
+
+typedef struct {
+    EVP_PKEY* pEcKeyPair;
+    BIGNUM*   pRegKey_BN;
+} pKeysSSL;
+
+static int cryptomb_ssl_ecdsa_keygen_en(uint64_t curve, struct buffer *Qx_buf,
+				                        struct buffer *Qy_buf, void **privkey)
+{
+    (void)Qx_buf; (void)Qy_buf; (void)privkey;
+    int ret = 0;
+
+    ec_type ec = ec_unset;
+    switch (curve & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+    set_ec_ssl_params(ec);
+
+    BIGNUM* st_reg_skey = BN_new();
+    BIGNUM* data_pub_x = BN_new();
+    BIGNUM* data_pub_y = BN_new();
+
+    EVP_PKEY* ecKeyPair = 0;
+    ecKeyPair = openssl_generate_keys_bn(st_reg_skey, data_pub_x, data_pub_y, NULL, EC, curvename, len8, 0);
+
+    pKeysSSL* sslPrivKey = (pKeysSSL*)malloc(sizeof(pKeysSSL));
+    sslPrivKey->pEcKeyPair = ecKeyPair;
+    sslPrivKey->pRegKey_BN = st_reg_skey;
+    *privkey = sslPrivKey;
+
+    /* Get X component of pub key */
+    alloc_buf(len8, Qx_buf);
+    memset(Qx_buf->buf, 0, len8);
+    BN_bn2binpad(data_pub_x, Qx_buf->buf, Qx_buf->len);
+
+    /* Get Y component of pub key */
+    alloc_buf(len8, Qy_buf);
+    memset(Qy_buf->buf, 0, len8);
+    BN_bn2binpad(data_pub_y, Qy_buf->buf, Qy_buf->len);
+
+out:
+	return ret;
+}
+
+static void cryptomb_ssl_ecdsa_free_key(void *privkey)
+{
+    (void)privkey;
+
+    EC_GROUP_free(EC);
+
+    pKeysSSL* sslPrivKey = ( pKeysSSL* )privkey;
+    EVP_PKEY_free(sslPrivKey->pEcKeyPair);
+    BN_free(&sslPrivKey->pRegKey_BN);
+    free(sslPrivKey);
+}
+
+static int cryptomb_ssl_ecdsa_siggen(struct ecdsa_siggen_data *data, flags_t parsed_flags)
+{
+    (void)parsed_flags; (void)data;
+    int ret = 0;
+
+    ec_type ec = ec_unset;
+
+    int add = 0;
+    switch (data->cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+            add = 2;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+    (void)ec; (void)add;
+
+    // message
+    int msgByteSize = data->msg.len;
+    int8u data_msg_digest[MBX_NUM_BUFFERS][maxMsgDigestSize] = { 0 };
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        memcpy(data_msg_digest[i]+add, data->msg.buf, msgByteSize);
+    }
+    int8u* pa_msg_digest[MBX_NUM_BUFFERS] = {data_msg_digest[0], data_msg_digest[1], data_msg_digest[2], data_msg_digest[3],
+                                       data_msg_digest[4], data_msg_digest[5], data_msg_digest[6], data_msg_digest[7]};
+    BIGNUM* bn_msg = BN_new();
+    BN_hex2bn(&bn_msg, (char*)data_msg_digest[0]);
+
+    /* private keys */
+    BIGNUM* bn_k[MBX_NUM_BUFFERS] = {0,0,0,0,0,0,0,0};
+    BIGNUM* bn_regk[MBX_NUM_BUFFERS] = {0,0,0,0,0,0,0,0};
+
+    pKeysSSL* sslPrivKey = (pKeysSSL*)data->privkey;
+    bn_regk[0] = BN_new();
+    BN_copy(bn_regk[0], sslPrivKey->pRegKey_BN);
+
+    ECDSA_SIG* sign = openssl_generate_signature(data_msg_digest[0], BN_num_bytes(bn_msg), sslPrivKey->pEcKeyPair);
+
+    // reference to sign' components
+    const BIGNUM* signR = 0; const BIGNUM* signS = 0;
+    ECDSA_SIG_get0(sign, &signR, &signS);
+
+    bn_k[0] = BN_new();
+    openssl_restore_eph_key_bn(&bn_k[0], bn_regk[0], signR, signS, bn_msg, EC);
+
+    for(int i = 1; i < MBX_NUM_BUFFERS; i++) {
+        bn_k[i] = BN_new();
+        bn_regk[i] = BN_new();
+
+        BN_copy(bn_k[i], bn_k[0]);
+        BN_copy(bn_regk[i], bn_regk[0]);
+    }
+
+    /* Output signature */
+    create_and_clean_mbx_buffer_int8u(sign_r);
+    create_and_clean_mbx_buffer_int8u(sign_s);
+    create_and_clean_mbx_buffer_int8u(sign_r_partial_api);
+    create_and_clean_mbx_buffer_int8u(sign_s_partial_api);
+
+    /* Main API*/
+    mbx_status sts = mbx_nistp_ecdsa_sign_ssl_mb8(pa_sign_r, pa_sign_s,
+                                                 (const int8u**)pa_msg_digest,
+                                                 (const int64u**)bn_k,
+                                                 (const int64u**)bn_regk,
+                                                 0);
+
+    /* Patrial API */
+    BIGNUM* pabn_inv_eph_key[8] = {0,0,0,0,0,0,0,0};
+    BIGNUM* pabn_sign_rp[8]     = {0,0,0,0,0,0,0,0};
+    for(int k = 0; k < 8; k++) {
+        pabn_inv_eph_key[k] = BN_new();
+        pabn_sign_rp[k] = BN_new();
+    }
+
+    mbx_status sts_partial = mbx_nistp_ecdsa_sign_setup_ssl_mb8(pabn_inv_eph_key, pabn_sign_rp, bn_k, NULL);
+    CKNULL_LOG((sts_partial == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecdsa_sign_setup_ssl_mb8")
+
+    sts_partial = mbx_nistp_ecdsa_sign_complete_ssl_mb8(pa_sign_r_partial_api, pa_sign_s_partial_api, pa_msg_digest,
+       (const BIGNUM**)pabn_sign_rp, (const BIGNUM**)pabn_inv_eph_key, bn_regk, NULL);
+    CKNULL_LOG((sts_partial == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecdsa_sign_complete_ssl_mb8")
+
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        int flag_r = memcmp(pa_sign_r[0], pa_sign_r[i], len8);
+        int flag_s = memcmp(pa_sign_s[0], pa_sign_s[i], len8);
+
+        if(flag_r || flag_s) {
+            logger(LOGGER_ERR, "Result NOT VALID, buffers differ\n");
+            sts = MBX_SET_STS_ALL(MBX_STATUS_MISMATCH_PARAM_ERR);
+            break;
+        }
+    }
+
+    if(sts == MBX_STATUS_OK) {
+        /* Get S component */
+        alloc_buf(len8, &data->S);
+        memset(data->S.buf, 0, len8);
+        memcpy(data->S.buf, pa_sign_s[0], len8);
+
+        /* Get R component */
+        alloc_buf(len8, &data->R);
+        memset(data->R.buf, 0, len8);
+        memcpy(data->R.buf, pa_sign_r[0], len8);
+    }
+
+out:
+    BN_free(bn_msg);
+    ECDSA_SIG_free(sign);
+
+    return ret;
+}
+
+static int cryptomb_ssl_ecdsa_sigver(struct ecdsa_sigver_data *data, flags_t parsed_flags)
+{
+    (void)parsed_flags;
+    int ret = 0;
+
+    /* "Feature" of p521 curve - padd the message with leading zeros to 528 bits */
+    int offset = 0;
+    ec_type ec = ec_unset;
+    switch (data->cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+            offset = 2;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+
+    set_ec_ssl_params(ec);
+
+    int8u data_msg_digest[MBX_NUM_BUFFERS][maxMsgDigestSize] = { 0 };
+    ECDSA_SIG* pabn_sign[MBX_NUM_BUFFERS] = { 0,0,0,0,0,0,0,0 };
+    BIGNUM* pabn_pubX[MBX_NUM_BUFFERS]    = { 0,0,0,0,0,0,0,0 };
+    BIGNUM* pabn_pubY[MBX_NUM_BUFFERS]    = { 0,0,0,0,0,0,0,0 };
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        BIGNUM *BN_r = BN_new();
+        BIGNUM *BN_s = BN_new();
+        pabn_sign[i] = ECDSA_SIG_new();
+        BN_bin2bn(data->R.buf, data->R.len, BN_r);
+        BN_bin2bn(data->S.buf, data->S.len, BN_s);
+        ECDSA_SIG_set0(pabn_sign[i], BN_r, BN_s);
+
+        memcpy(data_msg_digest[i]+offset, data->msg.buf, data->msg.len);
+
+        pabn_pubX[i] = BN_new();
+        BN_bin2bn(data->Qx.buf, data->Qx.len, pabn_pubX[i]);
+
+        pabn_pubY[i] = BN_new();
+        BN_bin2bn(data->Qy.buf, data->Qy.len, pabn_pubY[i]);
+    }
+
+    /* msg */
+    int8u* pa_msg_digest[MBX_NUM_BUFFERS] = {data_msg_digest[0], data_msg_digest[1], data_msg_digest[2], data_msg_digest[3],
+                                       data_msg_digest[4], data_msg_digest[5], data_msg_digest[6], data_msg_digest[7]};
+
+    /* Verify */
+    mbx_status sts = mbx_nistp_ecdsa_verify_ssl_mb8((const ECDSA_SIG**)pabn_sign,
+                                                       (const int8u**)pa_msg_digest,
+                                                       (const BIGNUM**)pabn_pubX,
+                                                       (const BIGNUM**)pabn_pubY,
+                                                       NULL, 0);
+    data->sigver_success = 1;
+    if (MBX_STATUS_OK != sts) {
+        data->sigver_success = 0;
+    }
+
+out:
+    return ret;
+}
+
+static struct ecdsa_backend cryptomb_ssl_ecdsa =
+{
+	NULL,                        /* ecdsa_keygen_testing */
+	NULL,
+	NULL,                        /* ecdsa_pkvver */
+	cryptomb_ssl_ecdsa_siggen,   /* ecdsa_siggen */
+	cryptomb_ssl_ecdsa_sigver,   /* ecdsa_sigver */
+	cryptomb_ssl_ecdsa_keygen_en,
+	cryptomb_ssl_ecdsa_free_key,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_ssl_ecdsa_backend)
+static void cryptomb_ssl_ecdsa_backend(void)
+{
+	register_ecdsa_impl(&cryptomb_ssl_ecdsa);
+}
+
+/************************************************
+ * ECDH interface functions
+ ************************************************/
+static int
+cryptomb_ssl_ecdh_ss_common(uint64_t cipher, struct buffer *Qxrem, struct buffer *Qyrem,
+                            struct buffer *privloc, struct buffer *Qxloc, struct buffer *Qyloc,
+                            struct buffer *hashzz)
+{
+    int ret = 0;
+    mbx_status sts = MBX_STATUS_OK;
+    ec_type ec = ec_unset;
+
+    int add = 0;
+    switch (cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            ec = nistp256;
+			break;
+		case ACVP_NISTP384:
+            ec = nistp384;
+			break;
+		case ACVP_NISTP521:
+            ec = nistp521;
+            add = 2;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+    set_ec_ssl_params(ec);
+
+    // A - remote
+    // B - local
+    create_and_clean_mbx_buffer_int64u(ifma_sharedAB);
+    BIGNUM* pa_pubAx[] = {0,0,0,0,0,0,0,0};
+    BIGNUM* pa_pubAy[] = {0,0,0,0,0,0,0,0};
+    BIGNUM* pa_pubBx[] = {0,0,0,0,0,0,0,0};
+    BIGNUM* pa_pubBy[] = {0,0,0,0,0,0,0,0};
+    BIGNUM* pa_prvB[] = {0,0,0,0,0,0,0,0};
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        pa_pubBx[i] = BN_new();
+        pa_pubBy[i] = BN_new();
+        pa_prvB[i] = BN_new();
+
+        pa_pubAx[i] = BN_new();
+        pa_pubAy[i] = BN_new();
+    }
+
+    if (Qxloc->len && Qyloc->len) {
+        for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+            BN_bin2bn(Qxloc->buf, Qxloc->len, pa_pubBx[i]);
+            BN_bin2bn(Qyloc->buf, Qyloc->len, pa_pubBy[i]);
+        }
+	}
+    if (privloc->len) {
+        for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+            BN_bin2bn(privloc->buf, privloc->len, pa_prvB[i]);
+        }
+	}
+    if(!(privloc->len && Qxloc->len && Qyloc->len)) {
+        // generate local keys - private with OpenSSL and public with crypto_mb
+        EVP_PKEY* ecKeyPair = 0;
+        ecKeyPair = openssl_generate_keys_bn(pa_prvB[0], NULL, NULL, NULL, EC, curvename, len8, 0);
+        for(int i = 1; i < MBX_NUM_BUFFERS; i++) {
+            BN_copy(pa_prvB[i], pa_prvB[0]);
+        }
+
+        sts = mbx_nistp_ecpublic_key_ssl_mb8(pa_pubBx, pa_pubBy, NULL, (const BIGNUM **)pa_prvB, 0);
+        CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecpublic_key_ssl_mb8")
+
+        alloc_buf(len8, Qxloc);
+        alloc_buf(len8, Qyloc);
+        BN_bn2binpad(pa_pubBx[0], Qxloc->buf, len8);
+        BN_bn2binpad(pa_pubBy[0], Qyloc->buf, len8);
+	}
+
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        BN_bin2bn(Qxrem->buf, Qxrem->len, pa_pubAx[i]);
+        BN_bin2bn(Qyrem->buf, Qyrem->len, pa_pubAy[i]);
+    }
+
+    sts = mbx_nistp_ecdh_ssl_mb8(pa_ifma_sharedAB, (const BIGNUM**)pa_prvB, (const BIGNUM**)pa_pubAx, (const BIGNUM**)pa_pubAy, NULL, 0);
+
+    for(int i = 1; i < MBX_NUM_BUFFERS; i++){
+        int cmp_flag = memcmp(pa_ifma_sharedAB[i],pa_ifma_sharedAB[0], len8);
+
+        if(cmp_flag){
+			logger(LOGGER_ERR, "Bad result, buffers differ\n");
+            ret = 0;
+            break;
+        }
+    }
+
+    /* Release resources */
+    for (int i = 0; i < 8; i++) {
+            BN_free(pa_pubAx[i]);
+            BN_free(pa_pubAy[i]);
+            BN_free(pa_pubBx[i]);
+            BN_free(pa_pubBy[i]);
+            BN_free(pa_prvB[i]);
+    }
+
+    if(hashzz->len){
+        if(memcmp(hashzz->buf, pa_ifma_sharedAB[0], len8)){
+            ret = -ENOENT;
+            goto out;
+        }
+    }
+    else{
+        alloc_buf(len8, hashzz);
+        memcpy(hashzz->buf, pa_ifma_sharedAB[0], len8);
+    }
+
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_nistp_ecdh_ssl_mb8")
+
+out:
+
+    return ret;
+}
+
+static int cryptomb_ssl_ecdh_ss(struct ecdh_ss_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+	return cryptomb_ssl_ecdh_ss_common(data->cipher, &data->Qxrem, &data->Qyrem,
+				      &data->privloc, &data->Qxloc,
+				      &data->Qyloc, &data->hashzz);
+}
+
+static int cryptomb_ssl_ecdh_ss_ver(struct ecdh_ss_ver_data *data,
+		flags_t parsed_flags)
+{
+    int ret = 0;
+	(void)parsed_flags;
+
+	ret = cryptomb_ssl_ecdh_ss_common(data->cipher, &data->Qxrem,
+                                      &data->Qyrem, &data->privloc,
+                                      &data->Qxloc, &data->Qyloc,
+                                      &data->hashzz);
+
+	if (ret == -EOPNOTSUPP || ret == -ENOENT) {
+		data->validity_success = 0;
+        return 0;
+	} else if (!ret) {
+		data->validity_success = 1;
+        return 0;
+	}
+
+	return ret;
+}
+
+static struct ecdh_backend cryptomb_ssl_ecdh =
+{
+	cryptomb_ssl_ecdh_ss,
+	cryptomb_ssl_ecdh_ss_ver,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_ssl_ecdh_backend)
+static void cryptomb_ssl_ecdh_backend(void)
+{
+    register_ecdh_impl(&cryptomb_ssl_ecdh);
+}
+
+/************************************************
+ * RSA pub exponent testing - OAEP KTS
+ ************************************************/
+static int cryptomb_rsa_kas_ifc_encrypt_common(struct kts_ifc_data *data, uint32_t *validation_success)
+{
+    (void)validation_success;
+
+    int ret = 0;
+    mbx_status sts = MBX_STATUS_OK;
+
+    struct kts_ifc_init_data *init = &data->u.kts_ifc_init;
+
+    int keyBitlen = data->keylen;
+    int modBytelen = data->modulus >> 3;
+
+    struct buffer *dkm_p, *c_p;
+
+    left_pad_buf(&init->n, data->modulus >> 3);
+    if (!init->dkm.len) {
+        alloc_buf(keyBitlen >> 3, &init->dkm);
+        RAND_bytes(init->dkm.buf, (int)init->dkm.len);
+
+        /*
+        * Ensure that in case of raw encryption, the value is
+        * not too large.
+        */
+        init->dkm.buf[0] &= ~0x80;
+    }
+    dkm_p = &init->dkm;
+    c_p = &init->iut_c;
+
+    /* output ciphertext */
+    int8u out_ciphertext[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN];
+    int8u *pa_ciphertext[MBX_NUM_BUFFERS] = {
+        out_ciphertext[0], out_ciphertext[1], out_ciphertext[2], out_ciphertext[3],
+        out_ciphertext[4], out_ciphertext[5], out_ciphertext[6], out_ciphertext[7]};
+
+    // plaintext
+    const int8u *pa_plaintext[MBX_NUM_BUFFERS] = {
+        dkm_p->buf, dkm_p->buf, dkm_p->buf, dkm_p->buf,
+        dkm_p->buf, dkm_p->buf, dkm_p->buf, dkm_p->buf};
+
+    // e
+    BIGNUM* BN_e = BN_new();
+    BN_bin2bn(init->e.buf, init->e.len, BN_e);
+    const BIGNUM *pa_e[MBX_NUM_BUFFERS] = {
+        (const BIGNUM *)BN_e, (const BIGNUM *)BN_e, (const BIGNUM *)BN_e, (const BIGNUM *)BN_e,
+        (const BIGNUM *)BN_e, (const BIGNUM *)BN_e, (const BIGNUM *)BN_e, (const BIGNUM *)BN_e};
+    // moduli
+    BIGNUM* BN_moduli = BN_new();
+    BN_bin2bn(init->n.buf, init->n.len, BN_moduli);
+    const BIGNUM *pa_moduli[MBX_NUM_BUFFERS] = {
+        (const BIGNUM *)BN_moduli, (const BIGNUM *)BN_moduli, (const BIGNUM *)BN_moduli, (const BIGNUM *)BN_moduli,
+        (const BIGNUM *)BN_moduli, (const BIGNUM *)BN_moduli, (const BIGNUM *)BN_moduli, (const BIGNUM *)BN_moduli};
+
+    const mbx_RSA_Method* method = mbx_RSA_pub65537_Method(data->modulus);
+    int rsaBitLen = init->n.len * 8;
+    int rsaByteLen = init->n.len;
+
+    // oaep encoding
+        int8u  seedMask[32] = {0};
+        int hashLen = 32;
+        int k = rsaByteLen;
+        int srcLen = dkm_p->len;
+        int8u* pSrc = dkm_p->buf;
+
+        int8u* pMaskedSeed = (int8u*)out_ciphertext[0]+1;
+        int8u* pMaskedDB = (int8u*)out_ciphertext[0] +hashLen +1;
+
+        out_ciphertext[0][0] = 0;
+        const IppsHashMethod* pMethod = ippsHashMethod_SHA256();
+
+        /* maskedDB = MGF(seed, k-1-hashLen)*/
+        ippsMGF1_rmf(pSeed, hashLen, pMaskedDB, k-1-hashLen, pMethod);
+
+        /* seedMask = HASH(pLab) */
+        ippsHashMessage_rmf(NULL, 0, seedMask, pMethod);
+
+        /* maskedDB ^= concat(HASH(pLab),PS,0x01,pSc) */
+        XorBlock(pMaskedDB, seedMask, pMaskedDB, hashLen);
+        pMaskedDB[k-srcLen-hashLen-2] ^= 0x01;
+        XorBlock(pMaskedDB+k-srcLen-hashLen-2+1, pSrc, pMaskedDB+k-srcLen-hashLen-2+1, srcLen);
+
+        /* seedMask = MGF(maskedDB, hashLen) */
+        ippsMGF1_rmf(pMaskedDB, k-1-hashLen, seedMask, hashLen, pMethod);
+        /* maskedSeed = seed ^ seedMask */
+        XorBlock(pSeed, seedMask, pMaskedSeed, hashLen);
+
+    sts = mbx_rsa_public_ssl_mb8(pa_ciphertext, pa_ciphertext, pa_e, pa_moduli, rsaBitLen);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_rsa_public_ssl_mb8\n")
+
+	alloc_buf(rsaByteLen, c_p);
+    memcpy(c_p->buf, pa_ciphertext[0], rsaByteLen);
+
+out:
+    BN_free(BN_moduli);
+    BN_free(BN_e);
+
+    return ret;
+}
+
+static int cryptomb_rsa_kas_ifc_decrypt_common(struct kts_ifc_data *data, int validation)
+{
+    (void)validation;
+    mbx_status sts = MBX_STATUS_OK;
+	int ret = 0;
+
+    struct kts_ifc_resp_data *resp = &data->u.kts_ifc_resp;
+	struct buffer *c_p=&resp->c;
+
+    left_pad_buf(&resp->n, data->modulus >> 3);
+    size_t keylen = (data->keylen) ? data->keylen : data->modulus;
+
+    // ciphertext
+    const int8u *pa_ciphertext[MBX_NUM_BUFFERS] = {
+        c_p->buf, c_p->buf, c_p->buf, c_p->buf,
+        c_p->buf, c_p->buf, c_p->buf, c_p->buf};
+
+    // plaintext
+    int8u out_plaintext[MBX_NUM_BUFFERS][MBX_RSA2K_DATA_BYTE_LEN];
+    int8u *pa_plaintext[MBX_NUM_BUFFERS] = {
+        out_plaintext[0], out_plaintext[1], out_plaintext[2], out_plaintext[3],
+        out_plaintext[4], out_plaintext[5], out_plaintext[6], out_plaintext[7]};
+
+    // private exponent
+    const int64u *pa_d[MBX_NUM_BUFFERS]= {
+        (int64u *)resp->d.buf, (int64u *)resp->d.buf, (int64u *)resp->d.buf, (int64u *)resp->d.buf,
+        (int64u *)resp->d.buf, (int64u *)resp->d.buf, (int64u *)resp->d.buf, (int64u *)resp->d.buf };
+
+    // moduli
+    const int64u *pa_moduli[MBX_NUM_BUFFERS] = {
+        (int64u *)resp->n.buf, (int64u *)resp->n.buf, (int64u *)resp->n.buf, (int64u *)resp->n.buf,
+        (int64u *)resp->n.buf, (int64u *)resp->n.buf, (int64u *)resp->n.buf, (int64u *)resp->n.buf};
+
+    /* key operation */
+    const mbx_RSA_Method* method = mbx_RSA2K_private_Method();
+
+    sts = mbx_rsa_private_mb8(pa_ciphertext, pa_plaintext, pa_d, pa_moduli, MBX_RSA2K_DATA_BIT_LEN, method, NULL);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_rsa_private_mb8\n")
+
+    BUFFER_INIT(tmp);
+	alloc_buf(MBX_RSA2K_DATA_BYTE_LEN, &tmp);
+    memcpy(tmp.buf, pa_plaintext[0], MBX_RSA2K_DATA_BYTE_LEN);
+
+    if (tmp.len < (keylen >> 3)) {
+        logger(LOGGER_ERR, "RSA decrypted data has insufficient size\n");
+    }
+
+    alloc_buf(keylen >> 3, &resp->dkm);
+    memcpy(resp->dkm.buf, tmp.buf, resp->dkm.len);
+
+out:
+	return ret;
+}
+
+static int cryptomb_kts_ifc_generate(struct kts_ifc_data *data,
+				    flags_t parsed_flags)
+{
+	int ret = 0;
+
+    (void)data; (void)parsed_flags;
+    if ((parsed_flags & FLAG_OP_KAS_ROLE_INITIATOR) &&
+	    (parsed_flags & FLAG_OP_AFT)) {
+		cryptomb_rsa_kas_ifc_encrypt_common(data, NULL);
+    }
+    else {
+        logger(LOGGER_ERR, "Unsupported test, only public exponent is tested with KTS.\n");
+        logger(LOGGER_ERR, "For private exponent test please use rsa_backend and rsa decryption primitive testing\n");
+        ret = -1;
+    }
+
+	return ret;
+}
+
+static struct kts_ifc_backend cryptomb_kts_ifc =
+{
+	cryptomb_kts_ifc_generate,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptomb_kts_ifc_backend)
+static void cryptomb_kts_ifc_backend(void)
+{
+	register_kts_ifc_impl(&cryptomb_kts_ifc);
+}
+
+/****************************************************
+ * RSA priv exponent testing - rsa decrypt privitive
+ ****************************************************/
+static int cryptombssl_rsa_keygen_en(struct buffer *ebuf, uint32_t modulus, void **privkey, struct buffer *nbuf)
+{
+    int ret = 0;
+
+	BIGNUM *egen = BN_new();
+    BIGNUM *n = BN_new();
+	EVP_PKEY *rsa = EVP_PKEY_new();
+
+    int64u e = 65537;
+    BIGNUM* bn_e = BN_new();
+    BN_set_word(bn_e, e);
+
+    int rsaBitsize = modulus;
+
+    ret = openssl_generate_rsa_key(rsa, bn_e, rsaBitsize);
+    CKNULL_LOG((ret == 1), ret, "Error in openssl_generate_rsa_key")
+
+    EVP_PKEY_get_bn_param(rsa, "n", &n);
+    EVP_PKEY_get_bn_param(rsa, "e", &egen);
+
+    /* Store n and e in output buffers */
+    alloc_buf(BN_num_bytes(egen), ebuf);
+	BN_bn2binpad(egen, ebuf->buf, BN_num_bytes(egen));
+    alloc_buf(BN_num_bytes(n), nbuf);
+    BN_bn2binpad(n, nbuf->buf, BN_num_bytes(n));
+
+    *privkey = rsa;
+
+out:
+    BN_free(bn_e);
+    BN_free(egen);
+    BN_free(n);
+
+	return ret;
+}
+
+static void cryptombssl_rsa_free_key(void *privkey)
+{
+	EVP_PKEY *rsa = (EVP_PKEY *)privkey;
+
+	if (rsa)
+		EVP_PKEY_free(rsa);
+}
+
+static int
+cryptombssl_rsa_decryption_primitive(struct rsa_decryption_primitive_data *data, flags_t parsed_flags)
+{
+	int ret = 1;
+    mbx_status sts = MBX_STATUS_OK;
+	(void)parsed_flags;
+
+    /* Define RSA bitlen */
+    int rsaByteLen = data->n.len;
+    int rsaBitsize = rsaByteLen*8;
+
+    /* output plaintext - allocate maximum possible buffer */
+    int8u out_plaintext_basic[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN] = {0};
+    int8u *pa_plaintext_basic[MBX_NUM_BUFFERS] = {
+        out_plaintext_basic[0], out_plaintext_basic[1], out_plaintext_basic[2], out_plaintext_basic[3],
+        out_plaintext_basic[4], out_plaintext_basic[5], out_plaintext_basic[6], out_plaintext_basic[7]};
+    int8u out_plaintext_crt[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN] = {0};
+    int8u *pa_plaintext_crt[MBX_NUM_BUFFERS] = {
+        out_plaintext_crt[0], out_plaintext_crt[1], out_plaintext_crt[2], out_plaintext_crt[3],
+        out_plaintext_crt[4], out_plaintext_crt[5], out_plaintext_crt[6], out_plaintext_crt[7]};
+    /* input ciphertext  */
+    int8u msg_buff[MBX_NUM_BUFFERS][MBX_RSA4K_DATA_BYTE_LEN];
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++){
+        memcpy(msg_buff[i], (const char*)data->msg.buf, data->msg.len);
+    }
+    int8u *pa_ciphertext[MBX_NUM_BUFFERS] = {
+        msg_buff[0], msg_buff[1], msg_buff[2], msg_buff[3],
+        msg_buff[4], msg_buff[5], msg_buff[6], msg_buff[7] };
+
+    /* classic parameters */
+    // private exponent and moduli
+    int64u *pa_d[MBX_NUM_BUFFERS];
+    int64u *pa_e[MBX_NUM_BUFFERS];
+    int64u *pa_n[MBX_NUM_BUFFERS];
+
+    /* CRT parameters */
+    // p, q primes and their CRT private exponent
+    BIGNUM *pa_p[MBX_NUM_BUFFERS];
+    BIGNUM *pa_q[MBX_NUM_BUFFERS];
+    BIGNUM *pa_dp[MBX_NUM_BUFFERS];
+    BIGNUM *pa_dq[MBX_NUM_BUFFERS];
+    /* CRT coefficient */
+    BIGNUM *pa_inv_q[MBX_NUM_BUFFERS];
+
+    /* Get RSA key info */
+	EVP_PKEY *rsa = data->privkey;
+
+    /* Get bignum components */
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        pa_n[i] = BN_new();
+        pa_e[i] = BN_new();
+        pa_d[i] = BN_new();
+        pa_p[i] = BN_new();
+        pa_q[i] = BN_new();
+        pa_dp[i] = BN_new();
+        pa_dq[i] = BN_new();
+        pa_inv_q[i] = BN_new();
+        EVP_PKEY_get_bn_param(rsa, "n", &pa_n[i]);
+        EVP_PKEY_get_bn_param(rsa, "e", &pa_e[i]);
+        EVP_PKEY_get_bn_param(rsa, "d", &pa_d[i]);
+        EVP_PKEY_get_bn_param(rsa, "rsa-factor1", &pa_p[i]);
+        EVP_PKEY_get_bn_param(rsa, "rsa-factor2", &pa_q[i]);
+        EVP_PKEY_get_bn_param(rsa, "rsa-exponent1", &pa_dp[i]);
+        EVP_PKEY_get_bn_param(rsa, "rsa-exponent2", &pa_dq[i]);
+        EVP_PKEY_get_bn_param(rsa, "rsa-coefficient1", &pa_inv_q[i]);
+    }
+
+    data->dec_result = 1;
+
+    /* Check message and generated modulus */
+    BIGNUM *bn_msg = BN_new();
+    BN_bin2bn(data->msg.buf, data->msg.len, bn_msg);
+    int cmp_bn_res = BN_cmp(bn_msg, pa_n[0]);
+    if(cmp_bn_res == 1){
+        logger(LOGGER_WARN, "Error, message is bigger than modulus\n");
+        data->dec_result = 0;
+        goto out;
+    }
+
+    sts = mbx_rsa_private_crt_ssl_mb8(pa_ciphertext, pa_plaintext_crt, pa_p, pa_q,
+                                  pa_dp, pa_dq, pa_inv_q, rsaBitsize);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_rsa_private_crt_ssl_mb8")
+
+    sts = mbx_rsa_private_ssl_mb8(pa_ciphertext, pa_plaintext_basic,
+                                (const int64u **)pa_d,
+                                (const int64u **)pa_n,
+                                rsaBitsize);
+    CKNULL_LOG((sts == MBX_STATUS_OK), sts, "Error in mbx_rsa_private_ssl_mb8")
+
+    /* Check the output */
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        int cmp_flag = memcmp(pa_plaintext_basic[i], pa_plaintext_basic[0], rsaByteLen);
+        if(cmp_flag){
+			logger(LOGGER_ERR, "Different output in buffers, the result is unexpected\n");
+            ret = -1;
+            break;
+        }
+        cmp_flag = memcmp(pa_plaintext_crt[i], pa_plaintext_basic[i], rsaByteLen);
+        if(cmp_flag){
+			logger(LOGGER_ERR, "Different output between crt and basic decryption\n");
+            ret = -1;
+            break;
+        }
+    }
+
+    if(!ret) {
+        data->dec_result = 0;
+    }
+    else{
+        alloc_buf(rsaByteLen, &data->s);
+        memcpy(data->s.buf, pa_plaintext_basic[0], rsaByteLen);
+    }
+
+out:
+    for(int i = 0; i < MBX_NUM_BUFFERS; i++) {
+        BN_free(pa_n[i]);
+        BN_free(pa_e[i]);
+        BN_free(pa_d[i]);
+        BN_free(pa_p[i]);
+        BN_free(pa_q[i]);
+        BN_free(pa_dp[i]);
+        BN_free(pa_dq[i]);
+        BN_free(pa_inv_q[i]);
+    }
+    BN_free(bn_msg);
+
+    return ret;
+}
+
+static struct rsa_backend cryptombssl_rsa =
+{
+	NULL, /* rsa_keygen */
+	NULL, /* rsa_siggen */
+	NULL, /* rsa_sigver */
+	NULL, /* rsa_keygen_prime */
+	NULL, /* rsa_keygen_prov_prime */
+	cryptombssl_rsa_keygen_en,
+	cryptombssl_rsa_free_key,
+	NULL,
+	cryptombssl_rsa_decryption_primitive,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(cryptombssl_rsa_backend)
+static void cryptombssl_rsa_backend(void)
+{
+	register_rsa_impl(&cryptombssl_rsa);
+}

--- a/backends/backend_ippcrypto.c
+++ b/backends/backend_ippcrypto.c
@@ -1,0 +1,1743 @@
+/*************************************************************************
+* Copyright (C) 2024 Intel Corporation
+*
+* Licensed under the Apache License,  Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* 	http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law  or agreed  to  in  writing,  software
+* distributed under  the License  is  distributed  on  an  "AS IS"  BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the  specific  language  governing  permissions  and
+* limitations under the License.
+*************************************************************************/
+
+#include "ippcp.h"
+#include "backend_common.h"
+#include "backend_ippcrypto_common.h"
+
+/************************************************************************************************
+ * Symmetric cipher interface functions - AES-CBC, AES-CBC_CS1/2/3, AES-CTR, AES-OFB, AES_OFB128
+ ************************************************************************************************/
+static Ipp8u savedIV[32];
+static int ippcp_mct_init(struct sym_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+    BUFFER_INIT(rawCtx)
+    int ctx_size;
+    if(data->cipher == ACVP_XTS) {
+        /* init context */
+        sts = ippsAES_XTSGetSize(&ctx_size);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_XTSGetSize")
+
+        CKINT(alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &rawCtx));
+        IppsAES_XTSSpec* spec = (IppsAES_XTSSpec*)(IPP_ALIGNED_PTR(rawCtx.buf, IPPCP_DATA_ALIGNMENT));
+        sts = ippsAES_XTSInit(data->key.buf, IPPCP_BYTES2BITS(data->key.len), data->data_len_bits, spec, ctx_size);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_XTSInit")
+    }
+    else {
+        /* init context */
+        sts = ippsAESGetSize(&ctx_size);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAESGetSize")
+
+        CKINT(alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &rawCtx));
+        IppsAESSpec* spec = (IppsAESSpec*)(IPP_ALIGNED_PTR(rawCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+        sts = ippsAESInit(data->key.buf, data->key.len, spec, ctx_size);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAESInit")
+
+        memcpy(savedIV, data->iv.buf, data->iv.len);
+    }
+	data->priv = rawCtx.buf;
+
+out:
+	return ret;
+}
+
+static int ippcp_mct_update(struct sym_data *data, flags_t parsed_flags)
+{
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+    IppsAESSpec* spec = NULL;
+    IppsAES_XTSSpec* xtsSpec = NULL;
+
+    if(data->cipher == ACVP_XTS) {
+        xtsSpec = (IppsAES_XTSSpec*)(IPP_ALIGNED_PTR(data->priv, IPPCP_DATA_ALIGNMENT));
+    }
+    else {
+        spec = (IppsAESSpec*)(IPP_ALIGNED_PTR(data->priv, IPPCP_DATA_ALIGNMENT));
+    }
+
+    BUFFER_INIT(cipherTxt)
+    alloc_buf(data->data.len, &cipherTxt);
+    memcpy(cipherTxt.buf, data->data.buf, data->data.len);
+
+    int bitLenLeft = data->data_len_bits;
+    int dataUnitByteLen = IPPCP_BITS2BYTES(data->xts_data_unit_len);
+    int procBitLen;
+
+    if (parsed_flags & FLAG_OP_ENC) {
+		logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "plaintext");
+        switch(data->cipher) {
+            case  ACVP_CBC: sts = ippsAESEncryptCBC(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CBC_CS1: sts = ippsAESEncryptCBC_CS1(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CBC_CS2: sts = ippsAESEncryptCBC_CS2(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CBC_CS3: sts = ippsAESEncryptCBC_CS3(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CFB128: sts = ippsAESEncryptCFB(data->data.buf, data->data.buf, data->data.len, data->iv.len , spec, data->iv.buf); break;
+            case  ACVP_CTR: sts = ippsAESEncryptCTR(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf, data->iv.len); break;
+            case  ACVP_OFB: sts = ippsAESEncryptOFB(data->data.buf, data->data.buf, data->data.len, data->iv.len, spec, data->iv.buf); break;
+            case  ACVP_XTS: {
+                int position = 0;
+                while(bitLenLeft > 0 && sts == ippStsNoErr) {
+                    procBitLen = (bitLenLeft > (int)data->xts_data_unit_len)? (int)data->xts_data_unit_len : bitLenLeft;
+                    Ipp8u* currentData = ((Ipp8u*)data->data.buf) + dataUnitByteLen*position;
+                    sts = ippsAES_XTSEncrypt(currentData, currentData, procBitLen, xtsSpec, data->iv.buf, position);
+                    bitLenLeft -= procBitLen;
+                    position++;
+                }
+                break;
+            }
+            default: break;
+        }
+
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAESEncrypt")
+        logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "ciphertext");
+
+        // Special handling for OFB mode
+        if(data->cipher != ACVP_OFB && data->cipher != ACVP_XTS)
+            memcpy(data->iv.buf, data->data.buf, data->iv.len);
+	}
+    else {
+		logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "ciphertext");
+        switch(data->cipher) {
+            case  ACVP_CBC: sts = ippsAESDecryptCBC(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CBC_CS1: sts = ippsAESDecryptCBC_CS1(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CBC_CS2: sts = ippsAESDecryptCBC_CS2(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CBC_CS3: sts = ippsAESDecryptCBC_CS3(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf); break;
+            case  ACVP_CFB128: sts = ippsAESDecryptCFB(data->data.buf, data->data.buf, data->data.len, data->iv.len , spec, data->iv.buf); break;
+            case  ACVP_CTR: sts = ippsAESDecryptCTR(data->data.buf, data->data.buf, data->data.len, spec, data->iv.buf, data->iv.len); break;
+            case  ACVP_OFB: sts = ippsAESDecryptOFB(data->data.buf, data->data.buf, data->data.len, data->iv.len, spec, data->iv.buf); break;
+            case  ACVP_XTS: {
+                const int aesXtsStartBlock = 0;
+                sts = ippsAES_XTSDecrypt(data->data.buf, data->data.buf,  data->xts_data_unit_len, xtsSpec, data->iv.buf, aesXtsStartBlock);
+                break;
+            }
+            default: break;
+        }
+
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAESDecrypt")
+		logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "plaintext");
+
+        // Special handling for OFB mode
+        if(data->cipher != ACVP_OFB && data->cipher != ACVP_XTS)
+            memcpy(data->iv.buf, cipherTxt.buf, data->iv.len);
+	}
+
+out:
+    free_buf(&cipherTxt);
+
+	return ret;
+}
+
+static int ippcp_mct_fini(struct sym_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+	(void)data;
+
+    if(data->cipher != ACVP_XTS) {
+        memcpy(data->iv.buf, savedIV, data->iv.len);
+    }
+
+    free(data->priv);
+    data->priv = NULL;
+
+	return 0;
+}
+
+static int ippcp_crypt(struct sym_data *data, flags_t parsed_flags)
+{
+	int ret = 0;
+
+	ret = ippcp_mct_init(data, parsed_flags);
+    CKINT_LOG(ret, "Error in ippcp_mct_init")
+	ret = ippcp_mct_update(data, parsed_flags);
+    CKINT_LOG(ret, "Error in ippcp_mct_update")
+	ret = ippcp_mct_fini(data, parsed_flags);
+    CKINT_LOG(ret, "Error in ippcp_mct_fini")
+
+out:
+	return ret;
+}
+
+static struct sym_backend ippcp_sym =
+{
+	ippcp_crypt,		/* encrypt */
+	ippcp_crypt,		/* decrypt */
+	ippcp_mct_init,		/* mct_init */
+	ippcp_mct_update,	/* mct_update */
+	ippcp_mct_fini,		/* mct_fini */
+};
+
+ACVP_DEFINE_CONSTRUCTOR(ippcp_sym_backend)
+static void ippcp_sym_backend(void)
+{
+	register_sym_impl(&ippcp_sym);
+}
+
+/**********************************************************
+ * Symmetric cipher interface functions - AES-CCM, AES-GCM
+ **********************************************************/
+static int ippcp_gcm_encrypt(struct aead_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+ 	uint32_t tagByteLen = IPPCP_BITS2BYTES(data->taglen);
+	alloc_buf(tagByteLen, &data->tag);
+
+    int ctx_size;
+    sts = ippsAES_GCMGetSize(&ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMGetSize")
+
+    BUFFER_INIT(gcmCtx)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &gcmCtx);
+    IppsAES_GCMState* state = (IppsAES_GCMState*)(IPP_ALIGNED_PTR(gcmCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+    sts = ippsAES_GCMInit(data->key.buf, data->key.len, state, ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMInit")
+
+    sts = ippsAES_GCMStart(data->iv.buf, data->iv.len, data->assoc.buf, data->assoc.len, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMStart")
+
+    if(data->data.buf != NULL) {
+        logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "plaintext");
+        sts = ippsAES_GCMEncrypt(data->data.buf, data->data.buf, data->data.len, state);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMEncrypt")
+    }
+
+    sts = ippsAES_GCMGetTag(data->tag.buf, tagByteLen, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMGetTag")
+
+out:
+    free_buf(&gcmCtx);
+	return ret;
+}
+
+static int ippcp_gcm_decrypt(struct aead_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+ 	uint32_t tagByteLen = IPPCP_BITS2BYTES(data->taglen);
+
+    int ctx_size;
+    sts = ippsAES_GCMGetSize(&ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMGetSize")
+
+    BUFFER_INIT(gcmCtx)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &gcmCtx);
+    IppsAES_GCMState* state = (IppsAES_GCMState*)(IPP_ALIGNED_PTR(gcmCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+    sts = ippsAES_GCMInit(data->key.buf, data->key.len, state, ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMInit")
+
+    sts = ippsAES_GCMStart(data->iv.buf, data->iv.len, data->assoc.buf, data->assoc.len, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMStart")
+
+    logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "plaintext");
+    if(data->data.buf != NULL) {
+        sts = ippsAES_GCMDecrypt(data->data.buf, data->data.buf, data->data.len, state);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMDecrypt")
+    }
+
+    BUFFER_INIT(ippcpTag)
+    alloc_buf(tagByteLen, &ippcpTag);
+
+    sts = ippsAES_GCMGetTag(ippcpTag.buf, tagByteLen, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_GCMGetTag")
+
+    data->integrity_error = 0;
+    if(memcmp(ippcpTag.buf, data->tag.buf, tagByteLen)) {
+        data->integrity_error = 1;
+    }
+
+out:
+    free_buf(&ippcpTag);
+    free_buf(&gcmCtx);
+	return ret;
+}
+
+static int ippcp_ccm_encrypt(struct aead_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+ 	uint32_t tagByteLen = IPPCP_BITS2BYTES(data->taglen);
+	alloc_buf(tagByteLen, &data->tag);
+
+    int ctx_size;
+    sts = ippsAES_CCMGetSize(&ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMGetSize")
+
+    BUFFER_INIT(ccmCtx)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &ccmCtx);
+    IppsAES_CCMState* state = (IppsAES_CCMState*)(IPP_ALIGNED_PTR(ccmCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+    sts = ippsAES_CCMInit(data->key.buf, data->key.len, state, ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMInit")
+
+    sts = ippsAES_CCMMessageLen(data->data.len, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMMessageLen")
+
+    sts = ippsAES_CCMTagLen(tagByteLen, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMTagLen")
+
+    sts = ippsAES_CCMStart(data->iv.buf, data->iv.len, data->assoc.buf, data->assoc.len, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMStart")
+    logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "plaintext");
+
+    if(data->data.buf != NULL) {
+        sts = ippsAES_CCMEncrypt(data->data.buf, data->data.buf, data->data.len, state);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMEncrypt")
+    }
+
+    sts = ippsAES_CCMGetTag(data->tag.buf, tagByteLen, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMGetTag")
+
+out:
+    free_buf(&ccmCtx);
+	return ret;
+}
+
+static int ippcp_ccm_decrypt(struct aead_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+ 	uint32_t tagByteLen = IPPCP_BITS2BYTES(data->taglen);
+
+    int ctx_size;
+    sts = ippsAES_CCMGetSize(&ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMGetSize")
+
+    BUFFER_INIT(ccmCtx)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &ccmCtx);
+    IppsAES_CCMState* state = (IppsAES_CCMState*)(IPP_ALIGNED_PTR(ccmCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+    sts = ippsAES_CCMInit(data->key.buf, data->key.len, state, ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMInit")
+
+    sts = ippsAES_CCMMessageLen(data->data.len, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMMessageLen")
+
+    sts = ippsAES_CCMTagLen(tagByteLen, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMTagLen")
+
+    sts = ippsAES_CCMStart(data->iv.buf, data->iv.len, data->assoc.buf, data->assoc.len, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMStart")
+
+    if(data->data.buf != NULL) {
+        logger_binary(LOGGER_DEBUG, data->data.buf, data->data.len, "plaintext");
+        sts = ippsAES_CCMDecrypt(data->data.buf, data->data.buf, data->data.len, state);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMDecrypt")
+    }
+
+    BUFFER_INIT(ippcpTag)
+    alloc_buf(tagByteLen, &ippcpTag);
+
+    sts = ippsAES_CCMGetTag(ippcpTag.buf, tagByteLen, state);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CCMGetTag")
+
+    data->integrity_error = 0;
+    if(memcmp(ippcpTag.buf, data->tag.buf, tagByteLen)) {
+        data->integrity_error = 1;
+    }
+
+out:
+    free_buf(&ippcpTag);
+    free_buf(&ccmCtx);
+	return ret;
+}
+
+static struct aead_backend ippcp_aead =
+{
+	ippcp_gcm_encrypt,	/* gcm_encrypt */
+	ippcp_gcm_decrypt,	/* gcm_decrypt */
+	ippcp_ccm_encrypt,	/* ccm_encrypt */
+	ippcp_ccm_decrypt,	/* ccm_decrypt */
+};
+
+ACVP_DEFINE_CONSTRUCTOR(ippcp_aead_backend)
+static void ippcp_aead_backend(void)
+{
+	register_aead_impl(&ippcp_aead);
+}
+
+
+/************************************************
+ * CMAC/HMAC cipher interface functions
+ ************************************************/
+static int ippcp_hmac_generate(struct hmac_data *data)
+{
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+    int ctx_size;
+    sts = ippsHMACGetSize_rmf(&ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHMACGetSize_rmf")
+
+    BUFFER_INIT(hmacCtx)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &hmacCtx);
+
+    int macByteLen = IPPCP_BITS2BYTES(data->maclen);
+    BUFFER_INIT(tag1)
+    alloc_buf(macByteLen, &tag1);
+    BUFFER_INIT(tag2)
+    alloc_buf(macByteLen, &tag2);
+
+    IppsHMACState_rmf* pCtx = (IppsHMACState_rmf*)(IPP_ALIGNED_PTR(hmacCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+    sts = ippsHMACInit_rmf(data->key.buf, data->key.len, pCtx, ippsHashMethod_SHA256());
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHMACInit_rmf")
+
+    sts = ippsHMACUpdate_rmf(data->msg.buf, data->msg.len, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHMACUpdate_rmf")
+
+    sts = ippsHMACGetTag_rmf(tag1.buf, macByteLen, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHMACGetTag_rmf")
+
+    sts = ippsHMACFinal_rmf(tag2.buf, macByteLen, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHMACFinal_rmf")
+
+    alloc_buf(macByteLen, &data->mac);
+    if(!memcmp(tag1.buf, tag2.buf, macByteLen)) {
+        memcpy(data->mac.buf, tag1.buf, macByteLen);
+    }
+
+out:
+    free_buf(&tag1);
+    free_buf(&tag2);
+    free_buf(&hmacCtx);
+    return ret;
+}
+
+static int ippcp_cmac_generate(struct hmac_data *data)
+{
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+    int ctx_size;
+    sts = ippsAES_CMACGetSize(&ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CMACGetSize")
+
+    BUFFER_INIT(cmacCtx)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &cmacCtx);
+
+    int macByteLen = IPPCP_BITS2BYTES(data->maclen);
+    BUFFER_INIT(tag1)
+    alloc_buf(macByteLen, &tag1);
+    BUFFER_INIT(tag2)
+    alloc_buf(macByteLen, &tag2);
+
+    IppsAES_CMACState* pCtx = (IppsAES_CMACState*)(IPP_ALIGNED_PTR(cmacCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+    sts = ippsAES_CMACInit(data->key.buf, data->key.len, pCtx, ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CMACInit")
+
+    sts = ippsAES_CMACUpdate(data->msg.buf, data->msg.len, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CMACUpdate")
+
+    sts = ippsAES_CMACGetTag(tag1.buf, macByteLen, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CMACGetTag")
+
+    sts = ippsAES_CMACFinal(tag2.buf, macByteLen, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsAES_CMACFinal")
+
+    alloc_buf(macByteLen, &data->mac);
+    if(!memcmp(tag1.buf, tag2.buf, macByteLen)) {
+        memcpy(data->mac.buf, tag1.buf, macByteLen);
+    }
+    else {
+		ret = EINVAL;
+    }
+
+out:
+    free_buf(&tag1);
+    free_buf(&tag2);
+    free_buf(&cmacCtx);
+    return ret;
+}
+
+static int ippcp_mac_generate(struct hmac_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+	int ret = 0;
+
+    switch(data->cipher) {
+	case ACVP_AESCMAC: {
+		return ippcp_cmac_generate(data);
+        break;
+    }
+    case ACVP_HMACSHA2_256: {
+		return ippcp_hmac_generate(data);
+        break;
+    }
+	default: {
+		ret = EINVAL;
+        break;
+    }
+    }
+
+	return ret;
+}
+
+static struct hmac_backend ippcp_mac =
+{
+	ippcp_mac_generate,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(ippcp_mac_backend)
+static void ippcp_mac_backend(void)
+{
+	register_hmac_impl(&ippcp_mac);
+}
+
+/************************************************
+ * HASH interface functions
+ ************************************************/
+static int ippcp_hash_generate(struct sha_data *data, flags_t parsed_flags)
+{
+	(void)parsed_flags;
+
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+    int ctx_size;
+    sts = ippsHashGetSize_rmf(&ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHashGetSize_rmf")
+
+    BUFFER_INIT(hashCtx)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &hashCtx);
+
+    int macByteLen = 0;
+    IppsHashMethod* method = NULL;
+
+    switch (data->cipher) {
+        case ACVP_SHA256: method = (IppsHashMethod*)ippsHashMethod_SHA256(); macByteLen = 32; break;
+        case ACVP_SHA384: method = (IppsHashMethod*)ippsHashMethod_SHA384(); macByteLen = 48; break;
+        case ACVP_SHA512: method = (IppsHashMethod*)ippsHashMethod_SHA512(); macByteLen = 64; break;
+        default: break;
+    }
+
+    BUFFER_INIT(tag1)
+    alloc_buf(macByteLen, &tag1);
+    BUFFER_INIT(tag2)
+    alloc_buf(macByteLen, &tag2);
+    BUFFER_INIT(tag3)
+    alloc_buf(macByteLen, &tag3);
+
+    IppsHashState_rmf* pCtx = (IppsHashState_rmf*)(IPP_ALIGNED_PTR(hashCtx.buf, IPPCP_DATA_ALIGNMENT));
+
+    sts = ippsHashInit_rmf(pCtx, method);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHashInit_rmf")
+
+    sts = ippsHashUpdate_rmf(data->msg.buf, data->msg.len, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHashUpdate_rmf")
+
+    sts = ippsHashGetTag_rmf(tag1.buf, macByteLen, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHashGetTag_rmf")
+
+    sts = ippsHashFinal_rmf(tag2.buf, pCtx);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHashFinal_rmf")
+
+    sts = ippsHashMessage_rmf(data->msg.buf, data->msg.len, tag3.buf, method);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsHashMessage_rmf")
+
+    alloc_buf(macByteLen, &data->mac);
+    if(!memcmp(tag1.buf, tag2.buf, macByteLen) || !memcmp(tag1.buf, tag3.buf, macByteLen)) {
+        memcpy(data->mac.buf, tag1.buf, macByteLen);
+    }
+    else {
+		ret = EINVAL;
+    }
+
+out:
+    free_buf(&tag1);
+    free_buf(&tag2);
+    free_buf(&tag3);
+    return ret;
+}
+
+static struct sha_backend ippcp_sha =
+{
+	ippcp_hash_generate,	/* hash_generate */
+	NULL
+};
+
+ACVP_DEFINE_CONSTRUCTOR(ippcp_sha_backend)
+static void ippcp_sha_backend(void)
+{
+	register_sha_impl(&ippcp_sha);
+}
+
+/************************************************
+ * RSA interface functions
+ ************************************************/
+typedef struct  {
+    IppsRSAPrivateKeyState* pPrvKey;
+    IppsRSAPublicKeyState* pPubKey;
+} cpRsaKeyPair;
+
+static int ippcp_rsa_keygen_en(struct buffer *ebuf, uint32_t modulus, void **privkey, struct buffer *nbuf)
+{
+    (void)ebuf; (void)nbuf;
+
+    IppStatus sts = ippStsNoErr;
+    int ret = 0;
+
+    int pBitSize = modulus / 2;
+    int qBitSize = modulus / 2;
+    int modulusWordSize = modulus >> 3;
+
+    // Fixed public exponent is supported
+    const int pubExpWordSize = 1;
+    Ipp32u e0_data = 0x10001;
+
+    /* Initialize private key */
+    int privKeyByteSize = 0;
+    sts = ippsRSA_GetSizePrivateKeyType2(pBitSize, qBitSize, &privKeyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetSizePrivateKeyType2")
+    BUFFER_INIT(buffPrivKey)
+    alloc_buf(privKeyByteSize + IPPCP_DATA_ALIGNMENT, &buffPrivKey);
+    IppsRSAPrivateKeyState* pPrvKey = (IppsRSAPrivateKeyState*)buffPrivKey.buf;
+    sts = ippsRSA_InitPrivateKeyType2(pBitSize, qBitSize, pPrvKey, privKeyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_InitPrivateKeyType2")
+
+    /* Initialize BigNumber-s */
+    int e0ByteSize;
+    sts = ippsBigNumGetSize(pubExpWordSize, &e0ByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffE0)
+    alloc_buf(e0ByteSize + IPPCP_DATA_ALIGNMENT, &buffE0);
+    IppsBigNumState* E0 = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffE0.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippcp_init_set_bn(E0, pubExpWordSize,  ippBigNumPOS, &e0_data,  pubExpWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    int nByteSize;
+    sts = ippsBigNumGetSize(modulusWordSize, &nByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffN)
+    alloc_buf(nByteSize + IPPCP_DATA_ALIGNMENT, &buffN);
+    IppsBigNumState* N = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffN.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(modulusWordSize, N);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    int eByteSize;
+    sts = ippsBigNumGetSize(pubExpWordSize, &eByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffE)
+    alloc_buf(eByteSize + IPPCP_DATA_ALIGNMENT, &buffE);
+    IppsBigNumState* E = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffE.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(pubExpWordSize, E);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    int dByteSize;
+    sts = ippsBigNumGetSize(modulusWordSize, &dByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffD)
+    alloc_buf(dByteSize + IPPCP_DATA_ALIGNMENT, &buffD);
+    IppsBigNumState* D = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffD.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(modulusWordSize, D);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    /* Generate key pair */
+    int size;
+    sts = ippsRSA_GetBufferSizePrivateKey(&size, pPrvKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetBufferSizePrivateKey")
+    BUFFER_INIT(buffScratch)
+    alloc_buf(size + IPPCP_DATA_ALIGNMENT, &buffScratch);
+
+    sts = ippsPrimeGetSize(modulus, &size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsPrimeGetSize")
+    BUFFER_INIT(buffPrimeGen)
+    alloc_buf(size + IPPCP_DATA_ALIGNMENT, &buffPrimeGen);
+    IppsPrimeState* pPrimeG = (IppsPrimeState*)( buffPrimeGen.buf );
+    sts = ippsPrimeInit(modulus, pPrimeG);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsPrimeInit")
+
+    IppsPRNGState* pPRNG = newPRNG();
+
+    for(int n = 0; n < 10; n++) {
+        for(int m = 0; m < 10; m++) {
+            sts = ippcp_init_set_bn(E0, pubExpWordSize,  ippBigNumPOS, &e0_data,  pubExpWordSize);
+            CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+            sts = ippsRSA_GenerateKeys(E0, N, E, D, pPrvKey, buffScratch.buf,
+                                       0, pPrimeG, ippsPRNGen, pPRNG);
+            if(ippStsInsufficientEntropy == sts) {
+			    logger(LOGGER_WARN, "ippStsInsufficientEntropy\n");
+                e0_data += 2;
+                continue;
+            }
+            else {
+                if(sts != ippStsNoErr) { return sts;}
+            }
+        }
+
+        if(ippStsNoErr == sts) {
+            int bitSize;
+            ippsRef_BN(0, &bitSize, NULL, N);
+            if(bitSize == (int)modulus) {
+			    logger(LOGGER_DEBUG, "modulus bitsize: %d\n ", bitSize);
+                break;
+            }
+            else
+			    logger(LOGGER_WARN, "%d modulus generated instead of %d\n ", bitSize, modulus);
+        }
+    }
+
+    /* Initialize public key */
+    int pubKeySize;
+    ippsRSA_GetSizePublicKey(modulus, 17, &pubKeySize);
+    BUFFER_INIT(buffPubKey)
+    CKINT(alloc_buf(pubKeySize + IPPCP_DATA_ALIGNMENT, &buffPubKey));
+    IppsRSAPublicKeyState* pPubKey = (IppsRSAPublicKeyState*)buffPubKey.buf; // ALIGNEMENT here!
+    sts = ippsRSA_InitPublicKey(modulus, 17, pPubKey, pubKeySize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_InitPublicKey")
+    // set public key
+    sts = ippsRSA_SetPublicKey(N, E, pPubKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_SetPublicKey")
+
+    /* Propagate the generated key pair */
+    cpRsaKeyPair* locKeyPair = (cpRsaKeyPair*)malloc(sizeof(cpRsaKeyPair));
+    locKeyPair->pPrvKey = pPrvKey;
+    locKeyPair->pPubKey = pPubKey;
+
+    *privkey = locKeyPair;
+
+out:
+    free_buf(&buffE0);
+    free_buf(&buffN);
+    free_buf(&buffE);
+    free_buf(&buffD);
+    free_buf(&buffScratch);
+    free_buf(&buffPrimeGen);
+
+	return ret;
+}
+
+static int ippcp_rsa_siggen(struct rsa_siggen_data *data, flags_t parsed_flags)
+{
+    IppStatus sts = ippStsNoErr;
+    int ret = 0;
+    (void)parsed_flags;
+
+    int modulusWordSize = data->modulus >> 3;
+    int modulusByteSize = IPPCP_BITS2BYTES(data->modulus);
+    const int pubExpWordSize = 1;
+
+    cpRsaKeyPair* locKeyPair = (cpRsaKeyPair*)data->privkey;
+
+    IppsRSAPrivateKeyState* pPrvKey = locKeyPair->pPrvKey;
+    IppsRSAPublicKeyState* pPubKey  = locKeyPair->pPubKey;
+
+    //calculate scratch buffer size
+    int buffSizePubKey = 0;
+    sts = ippsRSA_GetBufferSizePublicKey(&buffSizePubKey, pPubKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetBufferSizePublicKey")
+
+    // private
+    int buffSizePrivKey = 0;
+    sts = ippsRSA_GetBufferSizePrivateKey(&buffSizePrivKey, pPrvKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetBufferSizePrivateKey")
+
+    // resize buffer
+    int signBuffSize = (buffSizePubKey > buffSizePrivKey) ? buffSizePubKey : buffSizePrivKey;
+    BUFFER_INIT(pLocSignBuffer)
+    CKINT(alloc_buf(signBuffSize + IPPCP_DATA_ALIGNMENT, &pLocSignBuffer));
+
+    // set the necessary method
+    IppsHashMethod* method = NULL;
+    switch (data->cipher) {
+	case ACVP_HMACSHA2_256:
+	case ACVP_SHA256:
+		method = (IppsHashMethod*)ippsHashMethod_SHA256_TT();
+		break;
+	case ACVP_HMACSHA2_384:
+	case ACVP_SHA384:
+		method = (IppsHashMethod*)ippsHashMethod_SHA384();
+		break;
+	case ACVP_HMACSHA2_512:
+	case ACVP_SHA512:
+		method = (IppsHashMethod*)ippsHashMethod_SHA512();
+		break;
+    }
+
+    CKINT(alloc_buf(modulusByteSize, &data->sig));
+    Ipp8u* salt = NULL;
+    if(data->saltlen) {
+        salt = malloc(data->saltlen);
+    }
+
+    // RSA sign
+    if(parsed_flags &FLAG_OP_RSA_SIG_PKCS1PSS) {
+        sts = ippsRSASign_PSS_rmf(data->msg.buf,data->msg.len, salt, data->saltlen, data->sig.buf, pPrvKey,
+                                    pPubKey, method, pLocSignBuffer.buf);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSASign_PSS_rmf")
+    }
+    else {
+        sts = ippsRSASign_PKCS1v15_rmf(data->msg.buf,data->msg.len, data->sig.buf, pPrvKey, pPubKey,
+                                        method, pLocSignBuffer.buf);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSASign_PKCS1v15_rmf")
+    }
+
+    int eByteSize;
+    sts = ippsBigNumGetSize(pubExpWordSize, &eByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffE)
+    alloc_buf(eByteSize + IPPCP_DATA_ALIGNMENT, &buffE);
+    IppsBigNumState* E = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffE.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(pubExpWordSize, E);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    int nByteSize;
+    sts = ippsBigNumGetSize(modulusWordSize, &nByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffN)
+    alloc_buf(nByteSize + IPPCP_DATA_ALIGNMENT, &buffN);
+    IppsBigNumState* N = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffN.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(modulusWordSize, N);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    sts = ippsRSA_GetPublicKey(N, E, pPubKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetPublicKey")
+
+    IppsBigNumSGN tmpSgn;
+    int tmpSize;
+    // Get E
+    ippsRef_BN(NULL, &tmpSize, NULL, E);
+    tmpSize = IPPCP_BITS2BYTES(tmpSize);
+    alloc_buf(tmpSize, &data->e);
+    sts = ippsGet_BN(&tmpSgn, &tmpSize, (Ipp32u*)data->e.buf, E);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGet_BN")
+
+    // Get N
+    ippsRef_BN(NULL, &tmpSize, NULL, N);
+    (alloc_buf(IPPCP_BITS2BYTES(tmpSize), &data->n));
+    BUFFER_INIT(tmpNNNN);
+    alloc_buf(IPPCP_BITS2BYTES(tmpSize), &tmpNNNN);
+    ippsRef_BN(&tmpSgn, &tmpSize, (Ipp32u**)&(tmpNNNN.buf), N);
+    dataReverse(data->n.buf, (const char *)tmpNNNN.buf, IPPCP_BITS2BYTES(tmpSize));
+
+out:
+    free_buf(&buffN);
+    free_buf(&buffE);
+    free_buf(&pLocSignBuffer);
+    if(data->saltlen) {
+        free(salt);
+    }
+
+    return ret;
+}
+
+/* Supported public exponent value is 0x10001 */
+static int ippcp_rsa_sigver(struct rsa_sigver_data *data, flags_t parsed_flags)
+{
+    IppStatus sts = ippStsNoErr;
+    int ret = 0;
+
+    int pubExpWordSize  = (data->e.len + 3) / 4;
+    int modulusWordSize = (data->n.len + 3) / 4;
+    int modulusBitSize  = IPPCP_BYTES2BITS(data->n.len);
+    int pubExpBitSize   = IPPCP_BYTES2BITS(data->e.len);
+
+    /* Initialize BigNumber-s */
+    int eByteSize;
+    sts = ippsBigNumGetSize(pubExpWordSize, &eByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+
+    BUFFER_INIT(buffE)
+    alloc_buf(eByteSize + IPPCP_DATA_ALIGNMENT, &buffE);
+    IppsBigNumState* bnE = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffE.buf, IPPCP_DATA_ALIGNMENT));
+
+    int nByteSize;
+    sts = ippsBigNumGetSize(modulusWordSize, &nByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+
+    BUFFER_INIT(buffN)
+    alloc_buf(nByteSize + IPPCP_DATA_ALIGNMENT, &buffN);
+    IppsBigNumState* bnN = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffN.buf, IPPCP_DATA_ALIGNMENT));
+
+    BUFFER_INIT(reversedN)
+    alloc_buf(data->n.len, &reversedN);
+    dataReverse(/* pBuf = */reversedN.buf,/* str = */(const char*)data->n.buf, data->n.len);
+
+    sts = ippcp_init_set_bn(bnE, pubExpWordSize,  ippBigNumPOS, (const Ipp32u *)data->e.buf,  pubExpWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+    sts = ippcp_init_set_bn(bnN, modulusWordSize, ippBigNumPOS, (const Ipp32u *)reversedN.buf, modulusWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    /* Initialize public key */
+    int pubKeyByteSize = 0;
+    ippsRSA_GetSizePublicKey(modulusBitSize, pubExpBitSize, &pubKeyByteSize);
+    BUFFER_INIT(buffPubKey)
+    alloc_buf(pubKeyByteSize + IPPCP_DATA_ALIGNMENT, &buffPubKey);
+    IppsRSAPublicKeyState* pPubKey = (IppsRSAPublicKeyState*)(IPP_ALIGNED_PTR(buffPubKey.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsRSA_InitPublicKey(modulusBitSize, pubExpBitSize, pPubKey, pubKeyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_InitPublicKey")
+
+    /* Set public and private keys */
+    sts = ippsRSA_SetPublicKey(bnN, bnE, pPubKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_SetPublicKey")
+
+    /* RSA signature and verification buffers */
+    int buffSize = 0;
+    sts = ippsRSA_GetBufferSizePublicKey(&buffSize, pPubKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetBufferSizePublicKey")
+
+    BUFFER_INIT(buffWork)
+    alloc_buf(buffSize + IPPCP_DATA_ALIGNMENT, &buffWork);
+    Ipp8u* pLocVerifBuffer = (IPP_ALIGNED_PTR(buffWork.buf, IPPCP_DATA_ALIGNMENT));
+
+    IppsHashMethod* method = NULL;
+
+    switch (data->cipher) {
+	case ACVP_HMACSHA2_256:
+	case ACVP_SHA256:
+		method = (IppsHashMethod*)ippsHashMethod_SHA256_TT();
+		break;
+	case ACVP_HMACSHA2_384:
+	case ACVP_SHA384:
+		method = (IppsHashMethod*)ippsHashMethod_SHA384();
+		break;
+	case ACVP_HMACSHA2_512:
+	case ACVP_SHA512:
+		method = (IppsHashMethod*)ippsHashMethod_SHA512();
+		break;
+    }
+
+    /* RSA Signature Verification */
+    int isValid = 1;
+    if(parsed_flags & FLAG_OP_RSA_SIG_PKCS1PSS){
+        sts = ippsRSAVerify_PSS_rmf(data->msg.buf,data->msg.len, data->sig.buf, &isValid, pPubKey,
+                                    method, pLocVerifBuffer);
+    }
+    else{
+        sts = ippsRSAVerify_PKCS1v15_rmf(data->msg.buf,data->msg.len, data->sig.buf, &isValid, pPubKey,
+                                         method, pLocVerifBuffer);
+    }
+
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSAVerify_PSS_rmf or ippsRSAVerify_PKCS1v15_rmf")
+
+    data->sig_result = 1;
+    if(isValid == 0)  {
+        data->sig_result = 0;
+    }
+
+out:
+    free_buf(&buffE);
+    free_buf(&buffN);
+    free_buf(&reversedN);
+    free_buf(&buffPubKey);
+    free_buf(&buffWork);
+	return ret;
+}
+
+static void ippcp_rsa_free_key(void *privkey)
+{
+    cpRsaKeyPair* locKeyPair = (cpRsaKeyPair*)privkey;
+
+	if (locKeyPair) {
+	    free(locKeyPair->pPrvKey);
+	    free(locKeyPair->pPubKey);
+        free(locKeyPair);
+    }
+}
+
+static struct rsa_backend ippcp_rsa =
+{
+	NULL,                 /* rsa_keygen */
+	ippcp_rsa_siggen,     /* rsa_siggen */
+	ippcp_rsa_sigver,     /* rsa_sigver */
+	NULL,                 /* rsa_keygen_prime */
+	NULL,		          /* rsa_keygen_prov_prime */
+    ippcp_rsa_keygen_en,  /* rsa_keygen_en*/
+    ippcp_rsa_free_key,   /* rsa_free_key */
+	NULL,
+	NULL,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(ippcp_rsa_backend)
+static void ippcp_rsa_backend(void)
+{
+	register_rsa_impl(&ippcp_rsa);
+}
+
+/********************************
+ * RSA OAEP functions
+ ********************************/
+static int ippcp_rsa_kas_ifc_encrypt_common(struct kts_ifc_data *data, uint32_t *validation_success)
+{
+    (void)validation_success;
+
+    IppStatus sts = ippStsNoErr;
+    int ret = 0;
+
+    struct kts_ifc_init_data *init = &data->u.kts_ifc_init;
+
+    /* Get the necessary lengths */
+    int modulusBitSize  = data->modulus;
+    int modulusByteSize = IPPCP_BITS2BYTES(data->modulus);
+    int modulusWordSize = (modulusBitSize + 31)/32;
+
+    int pubExpByteSize  = init->e.len;
+    int pubExpBitSize   = IPPCP_BYTES2BITS(pubExpByteSize);
+    int pubExpWordSize  = (pubExpByteSize + 3)/4;
+
+    int keyBitlen = data->keylen;
+	struct buffer *dkm_p, *c_p;
+
+    left_pad_buf(&init->n, data->modulus >> 3);
+    if (!init->dkm.len) {
+        alloc_buf(IPPCP_BITS2BYTES(keyBitlen), &init->dkm);
+        RAND_bytes(init->dkm.buf, (int)init->dkm.len);
+
+        /*
+        * Ensure that in case of raw encryption, the value is
+        * not too large.
+        */
+        init->dkm.buf[0] &= ~0x80;
+    }
+    dkm_p = &init->dkm; (void)dkm_p;
+    c_p = &init->iut_c; (void)c_p;
+
+    /* Initialize BigNumber-s */
+    int nByteSize;
+    sts = ippsBigNumGetSize(modulusWordSize, &nByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffN)
+    alloc_buf(nByteSize + IPPCP_DATA_ALIGNMENT, &buffN);
+    IppsBigNumState* bnN = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffN.buf, IPPCP_DATA_ALIGNMENT));
+
+    BUFFER_INIT(reversedN)
+    alloc_buf(modulusByteSize, &reversedN);
+    dataReverse(/* pBuf = */reversedN.buf,/* str = */(const char*)init->n.buf, init->n.len);
+
+    sts = ippcp_init_set_bn(bnN, modulusWordSize, ippBigNumPOS, (const Ipp32u *)reversedN.buf, modulusWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    int eByteSize;
+    sts = ippsBigNumGetSize(pubExpWordSize, &eByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffE)
+    alloc_buf(eByteSize + IPPCP_DATA_ALIGNMENT, &buffE);
+    IppsBigNumState* bnE = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffE.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippcp_init_set_bn(bnE, pubExpWordSize,  ippBigNumPOS, (const Ipp32u *)init->e.buf, pubExpWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    /* Initialize public key */
+    int pubKeyByteSize = 0;
+    sts = ippsRSA_GetSizePublicKey(modulusBitSize, pubExpBitSize, &pubKeyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetSizePublicKey")
+    BUFFER_INIT(buffPubKey)
+    alloc_buf(pubKeyByteSize + IPPCP_DATA_ALIGNMENT, &buffPubKey);
+    IppsRSAPublicKeyState* pPubKey = (IppsRSAPublicKeyState *)(IPP_ALIGNED_PTR(buffPubKey.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsRSA_InitPublicKey(modulusBitSize, pubExpBitSize, pPubKey, pubKeyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_InitPublicKey")
+
+    /* Set public key */
+    sts = ippsRSA_SetPublicKey(bnN, bnE, pPubKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_SetPublicKey")
+
+    /* RSA encryption */
+    int encBufSize;
+    sts = ippsRSA_GetBufferSizePublicKey(&encBufSize, pPubKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_SetPublicKey")
+    BUFFER_INIT(buffSgn)
+    alloc_buf(encBufSize + IPPCP_DATA_ALIGNMENT, &buffSgn);
+    Ipp8u* encScratchBuffer = (IPP_ALIGNED_PTR(buffSgn.buf, IPPCP_DATA_ALIGNMENT));
+
+	alloc_buf(modulusByteSize, c_p);
+    sts = ippsRSAEncrypt_OAEP_rmf(dkm_p->buf, dkm_p->len, NULL, 0, seed0, c_p->buf, pPubKey,
+                                  ippsHashMethod_SHA256(), encScratchBuffer);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSAEncrypt_OAEP_rmf")
+
+out:
+    free_buf(&buffN);
+    free_buf(&reversedN);
+    free_buf(&buffE);
+    free_buf(&buffPubKey);
+    free_buf(&buffSgn);
+
+    return ret;
+}
+
+static int ippcp_rsa_kas_ifc_set_key(IppsRSAPrivateKeyState *pPrivKey, struct buffer *n_buf,
+                                     struct buffer *e_buf, struct buffer *d_buf,
+                                     struct buffer *p_buf, struct buffer *q_buf,
+                                     struct buffer *dmp1_buf, struct buffer *dmq1_buf,
+                                     struct buffer *iqmp_buf)
+{
+    (void)e_buf; (void)p_buf; (void)q_buf; (void)dmp1_buf; (void)dmq1_buf; (void)iqmp_buf;
+
+    IppStatus sts = ippStsNoErr;
+    int ret = 0;
+
+    int privExpByteSize = d_buf->len;
+    int privExpWordSize = (privExpByteSize + 3)/4;
+
+    int modulusByteSize = n_buf->len;
+    int modulusWordSize = (modulusByteSize + 3)/4;
+
+    /* Initialize BigNumber-s */
+    int dByteSize;
+    sts = ippsBigNumGetSize(privExpWordSize, &dByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffD)
+    alloc_buf(dByteSize + IPPCP_DATA_ALIGNMENT, &buffD);
+    BUFFER_INIT(reversedD)
+    alloc_buf(modulusByteSize, &reversedD);
+    dataReverse(/* pBuf = */reversedD.buf,/* str = */(const char*)d_buf->buf, d_buf->len);
+    IppsBigNumState* bnD = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffD.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippcp_init_set_bn(bnD, privExpWordSize, ippBigNumPOS, (const Ipp32u *)reversedD.buf, privExpWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    int nByteSize;
+    sts = ippsBigNumGetSize(modulusWordSize, &nByteSize);
+    BUFFER_INIT(buffN)
+    alloc_buf(nByteSize + IPPCP_DATA_ALIGNMENT, &buffN);
+    IppsBigNumState* bnN = (IppsBigNumState *)(IPP_ALIGNED_PTR(buffN.buf, IPPCP_DATA_ALIGNMENT));
+    BUFFER_INIT(reversedN)
+    alloc_buf(modulusByteSize, &reversedN);
+    dataReverse(/* pBuf = */reversedN.buf,/* str = */(const char*)n_buf->buf, n_buf->len);
+    sts = ippcp_init_set_bn(bnN, modulusWordSize, ippBigNumPOS, (const Ipp32u *)reversedN.buf, modulusWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    /* Set private key */
+    sts = ippsRSA_SetPrivateKeyType1(bnN, bnD, pPrivKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_SetPrivateKeyType1")
+
+out:
+    free_buf(&buffD);
+    free_buf(&reversedD);
+    free_buf(&buffN);
+    free_buf(&reversedN);
+
+	return ret;
+}
+
+static int ippcp_rsa_kas_ifc_decrypt_common(struct kts_ifc_data *data, int validation)
+{
+    (void)validation;
+    IppStatus sts = ippStsNoErr;
+	int ret = 0;
+
+    struct kts_ifc_resp_data *resp = &data->u.kts_ifc_resp;
+	struct buffer *c_p=&resp->c;
+
+    left_pad_buf(&resp->n, data->modulus >> 3);
+
+    int privExpByteSize = resp->n.len;
+    int privExpBitSize  = IPPCP_BYTES2BITS(privExpByteSize);
+    int modulusByteSize = resp->n.len;
+    int modulusBitSize  = IPPCP_BYTES2BITS(modulusByteSize);
+
+    /* Initialize private key */
+    int privKeyByteSize = 0;
+    ippsRSA_GetSizePrivateKeyType1(modulusBitSize, privExpBitSize, &privKeyByteSize);
+    BUFFER_INIT(buffPrivKey)
+    alloc_buf(privKeyByteSize + IPPCP_DATA_ALIGNMENT, &buffPrivKey);
+    IppsRSAPrivateKeyState* pPrivKey = (IppsRSAPrivateKeyState*)(IPP_ALIGNED_PTR(buffPrivKey.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsRSA_InitPrivateKeyType1(modulusBitSize, privExpBitSize, pPrivKey, privKeyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_InitPrivateKeyType1")
+
+    ret = ippcp_rsa_kas_ifc_set_key(pPrivKey, &resp->n, &resp->e, &resp->d, &resp->p,
+                                    &resp->q,&resp->dmp1, &resp->dmq1, &resp->iqmp);
+    CKNULL_LOG((ret == 0), sts, "Error in ippcp_rsa_kas_ifc_set_key")
+
+	size_t outlen = data->modulus;
+    size_t keylen = (data->keylen) ? data->keylen : data->modulus;
+	BUFFER_INIT(tmp);
+	alloc_buf(outlen, &tmp);
+    int tmp_len = (int)tmp.len;
+
+    /* RSA decryption */
+    int decBufSize;
+    sts = ippsRSA_GetBufferSizePrivateKey(&decBufSize, pPrivKey);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetBufferSizePrivateKey")
+    BUFFER_INIT(buffScratch)
+    alloc_buf(decBufSize + IPPCP_DATA_ALIGNMENT, &buffScratch);
+    Ipp8u* decScratchBuffer = IPP_ALIGNED_PTR(buffScratch.buf, IPPCP_DATA_ALIGNMENT);
+
+    sts = ippsRSADecrypt_OAEP_rmf(c_p->buf, NULL, 0, tmp.buf, &tmp_len, pPrivKey,
+                                  ippsHashMethod_SHA256(), decScratchBuffer);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRSA_GetBufferSizePrivateKey")
+
+    CKNULL_LOG((tmp.len >= IPPCP_BITS2BYTES(keylen)), -EINVAL, "RSA decrypted data has insufficient size")
+
+    alloc_buf(IPPCP_BITS2BYTES(keylen), &resp->dkm);
+    memcpy(resp->dkm.buf, tmp.buf, resp->dkm.len);
+
+out:
+    free_buf(&buffPrivKey);
+	free_buf(&tmp);
+    free_buf(&buffScratch);
+
+	return ret;
+}
+
+static int ippcp_kts_ifc_generate(struct kts_ifc_data *data,
+				    flags_t parsed_flags)
+{
+	int ret = 0;
+    (void)data; (void)parsed_flags;
+    if ((parsed_flags & FLAG_OP_KAS_ROLE_INITIATOR) &&
+	    (parsed_flags & FLAG_OP_AFT)) {
+		ippcp_rsa_kas_ifc_encrypt_common(data, NULL);
+    }
+    else if ((parsed_flags & FLAG_OP_KAS_ROLE_RESPONDER) &&
+		   (parsed_flags & FLAG_OP_AFT)) {
+        ippcp_rsa_kas_ifc_decrypt_common(data, 0);
+    }
+
+	return ret;
+}
+
+static struct kts_ifc_backend ippcp_kts_ifc =
+{
+	ippcp_kts_ifc_generate,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(ippcp_kts_ifc_backend)
+static void ippcp_kts_ifc_backend(void)
+{
+	register_kts_ifc_impl(&ippcp_kts_ifc);
+}
+
+/************************************************
+ * ECDSA interface functions
+ ************************************************/
+typedef IppStatus (*InitStdFunction_t)(const IppsGFpState*, IppsGFpECState*);
+
+static int ippcp_ecdsa_keygen_en(uint64_t curve, struct buffer *Qx_buf, struct buffer *Qy_buf, void **privkey)
+{
+    IppStatus sts = ippStsNoErr;
+    int ret = 0;
+
+    int primeBitSize = 0, primeWordSize=0;
+    const IppsGFpMethod *pGFpMethod = NULL;
+    InitStdFunction_t initStdF      = NULL;
+    switch (curve & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            primeBitSize = 256;
+            primeWordSize = 8;
+			pGFpMethod = ippsGFpMethod_p256r1();
+            initStdF = ippsGFpECInitStd256r1;
+			break;
+		case ACVP_NISTP521:
+            primeBitSize = 521;
+            primeWordSize = 17;
+			pGFpMethod = ippsGFpMethod_p521r1();
+            initStdF = ippsGFpECInitStd521r1;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+
+    int ctx_size = 0;
+    sts = ippsGFpGetSize(primeBitSize, &ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpGetSize")
+    BUFFER_INIT(buffGFp)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &buffGFp);
+    IppsGFpState* pGF = (IppsGFpState*)(IPP_ALIGNED_PTR(buffGFp.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsGFpInitFixed(primeBitSize, pGFpMethod, pGF);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpInitFixed")
+
+    /* GFpEC context */
+    ctx_size = 0;
+    sts = ippsGFpECGetSize(pGF, &ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECGetSize")
+    BUFFER_INIT(buffGFpEC)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &buffGFpEC);
+    IppsGFpECState* pEC = (IppsGFpECState*)(IPP_ALIGNED_PTR(buffGFpEC.buf, IPPCP_DATA_ALIGNMENT));
+    sts = initStdF(pGF, pEC);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in initStdF")
+
+    /* Private key */
+    int privKeyCtxByteSize;
+    sts = ippsBigNumGetSize(primeWordSize, &privKeyCtxByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(bufPriv)
+    alloc_buf(privKeyCtxByteSize + IPPCP_DATA_ALIGNMENT, &bufPriv);
+    memset(bufPriv.buf, 0, privKeyCtxByteSize + IPPCP_DATA_ALIGNMENT);
+    IppsBigNumState* bnPrivate = (IppsBigNumState*)bufPriv.buf;
+    sts = ippsBigNumInit(primeWordSize, bnPrivate);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    IppsPRNGState* pRand = newPRNG();
+    Ipp32u isZeroRes;
+    do {
+        // get regular private key
+        sts = ippsGFpECPrivateKey(bnPrivate, pEC, ippsPRNGen, pRand);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECPrivateKey")
+
+        ippsCmpZero_BN(bnPrivate, &isZeroRes);
+    } while (isZeroRes == IS_ZERO);
+
+    *privkey = bnPrivate;
+
+    /* Tmp buffer */
+    int srcatchSize;
+    sts = ippsGFpECScratchBufferSize(2, pEC, &srcatchSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECScratchBufferSize")
+    BUFFER_INIT(buffScratch)
+    alloc_buf(srcatchSize + IPPCP_DATA_ALIGNMENT, &buffScratch);
+
+    /* Init public key */
+    int pubKeyCtxSize;
+    sts = ippsGFpECPointGetSize(pEC, &pubKeyCtxSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECPointGetSize")
+    BUFFER_INIT(buffPubKey)
+    alloc_buf(pubKeyCtxSize + IPPCP_DATA_ALIGNMENT, &buffPubKey);
+    memset(buffPubKey.buf, 0, pubKeyCtxSize + IPPCP_DATA_ALIGNMENT);
+    IppsGFpECPoint* regPublic = (IppsGFpECPoint*)(IPP_ALIGNED_PTR(buffPubKey.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsGFpECPointInit(NULL, NULL, regPublic, pEC);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECPointInit")
+
+    /* Generate public key */
+    sts = ippsGFpECPublicKey(bnPrivate, regPublic, pEC, buffScratch.buf);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECPublicKey")
+
+    /* Get components of pub key */
+    int xyByteSize;
+    sts = ippsBigNumGetSize(primeWordSize, &xyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffX)
+    alloc_buf(xyByteSize + IPPCP_DATA_ALIGNMENT, &buffX);
+    memset(buffX.buf, 0, xyByteSize + IPPCP_DATA_ALIGNMENT);
+    IppsBigNumState* bnX = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffX.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(primeWordSize, bnX);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    sts = ippsBigNumGetSize(primeWordSize, &xyByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffY)
+    alloc_buf(xyByteSize + IPPCP_DATA_ALIGNMENT, &buffY);
+    memset(buffY.buf, 0, xyByteSize + IPPCP_DATA_ALIGNMENT);
+    IppsBigNumState* bnY = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffY.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(primeWordSize, bnY);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumInit")
+
+    sts = ippsGFpECGetPointRegular(regPublic, bnX, bnY, pEC);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECGetPointRegular")
+
+    int tmpSize;
+
+    /* Get X component size */
+    ippsRef_BN(NULL, &tmpSize, NULL, bnX);
+    tmpSize = IPPCP_BITS2BYTES(tmpSize);
+    alloc_buf(tmpSize, Qx_buf);
+    memset(Qx_buf->buf, 0, tmpSize);
+    BUFFER_INIT(buffQxRevert);
+    alloc_buf(tmpSize, &buffQxRevert);
+    memset(buffQxRevert.buf, 0, tmpSize);
+    sts = ippsRef_BN(NULL, NULL, (Ipp32u**)&(buffQxRevert.buf), bnX);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRef_BN")
+    dataReverse(Qx_buf->buf, (const char *)buffQxRevert.buf, tmpSize);
+
+    /* Get Y component size */
+    ippsRef_BN(NULL, &tmpSize, NULL, bnY);
+    tmpSize = IPPCP_BITS2BYTES(tmpSize);
+    alloc_buf(tmpSize, Qy_buf);
+    memset(Qy_buf->buf, 0, tmpSize);
+    BUFFER_INIT(buffQyRevert);
+    alloc_buf(tmpSize, &buffQyRevert);
+    memset(buffQyRevert.buf, 0, tmpSize);
+    sts = ippsRef_BN(NULL, NULL, (Ipp32u**)&(buffQyRevert.buf), bnY);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRef_BN")
+    dataReverse(Qy_buf->buf, (const char *)buffQyRevert.buf, tmpSize);
+
+out:
+    free_buf(&buffGFp);
+    free_buf(&buffGFpEC);
+    free_buf(&buffScratch);
+    free_buf(&buffPubKey);
+    free_buf(&buffX);
+    free_buf(&buffY);
+
+	return ret;
+}
+
+static void ippcp_ecdsa_free_key(void *privkey)
+{
+	IppsBigNumState *pPrivKey = (IppsBigNumState *)privkey;
+
+	if (pPrivKey)
+		free((Ipp8u*)pPrivKey);
+}
+
+static int ippcp_ecdsa_siggen(struct ecdsa_siggen_data *data, flags_t parsed_flags)
+{
+    (void)parsed_flags;
+    IppStatus sts = ippStsNoErr;
+    int ret = 0;
+
+    int primeBitSize = 0, primeWordSize = 0, primeByteSize = 0;
+    const IppsGFpMethod *pGFpMethod = NULL;
+    InitStdFunction_t initStdF      = NULL;
+    switch (data->cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            primeBitSize = 256;
+            primeWordSize = 8;
+            primeByteSize = 32;
+			pGFpMethod = ippsGFpMethod_p256r1();
+            initStdF = ippsGFpECInitStd256r1;
+			break;
+		case ACVP_NISTP384:
+            primeBitSize = 384;
+            primeWordSize = 12;
+            primeByteSize = 48;
+			pGFpMethod = ippsGFpMethod_p384r1();
+            initStdF = ippsGFpECInitStd384r1;
+			break;
+		case ACVP_NISTP521:
+            primeBitSize = 521;
+            primeWordSize = 17;
+            primeByteSize = 66;
+			pGFpMethod = ippsGFpMethod_p521r1();
+            initStdF = ippsGFpECInitStd521r1;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+
+    int ctx_size = 0;
+    sts = ippsGFpGetSize(primeBitSize, &ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpGetSize")
+    BUFFER_INIT(buffGFp)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &buffGFp);
+    IppsGFpState* pGF = (IppsGFpState*)(IPP_ALIGNED_PTR(buffGFp.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsGFpInitFixed(primeBitSize, pGFpMethod, pGF);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpInitFixed")
+
+    /* GFpEC context */
+    ctx_size = 0;
+    sts = ippsGFpECGetSize(pGF, &ctx_size);
+    BUFFER_INIT(buffGFpEC)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &buffGFpEC);
+    IppsGFpECState* pEC = (IppsGFpECState*)(IPP_ALIGNED_PTR(buffGFpEC.buf, IPPCP_DATA_ALIGNMENT));
+    sts = initStdF(pGF, pEC);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in initStdF")
+
+    /* message */
+    int msgByteSize = data->msg.len;
+    int msgWordSize = (msgByteSize + 3)/4;
+    int msgCtxByteSize;
+    sts = ippsBigNumGetSize(msgWordSize, &msgCtxByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffMsg)
+    alloc_buf(msgCtxByteSize + IPPCP_DATA_ALIGNMENT, &buffMsg);
+    memset(buffMsg.buf, 0, msgCtxByteSize + IPPCP_DATA_ALIGNMENT);
+    IppsBigNumState* bnMsgDigest = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffMsg.buf, IPPCP_DATA_ALIGNMENT));
+
+    BUFFER_INIT(buffMsgTmp)
+    alloc_buf(msgByteSize, &buffMsgTmp);
+    memset(buffMsgTmp.buf, 0, msgByteSize);
+
+    dataReverse(buffMsgTmp.buf, (const char *)data->msg.buf, msgByteSize);
+
+    sts = ippcp_init_set_bn(bnMsgDigest, msgWordSize, ippBigNumPOS, (const Ipp32u *)buffMsgTmp.buf, msgWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    /* Reg and Eph private keys */
+    IppsBigNumState* bnRegPrivate = (IppsBigNumState*)data->privkey;
+    int ephKeyCtxByteSize;
+    sts = ippsBigNumGetSize(primeWordSize, &ephKeyCtxByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffEphKey)
+    alloc_buf(ephKeyCtxByteSize + IPPCP_DATA_ALIGNMENT, &buffEphKey);
+    memset(buffEphKey.buf, 0, ephKeyCtxByteSize + IPPCP_DATA_ALIGNMENT);
+
+    IppsBigNumState* bnEphPrivate = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffEphKey.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsBigNumInit(primeWordSize, bnEphPrivate);
+
+    IppsPRNGState* pRand = newPRNG();
+
+    Ipp32u isZeroRes, isEquRes;
+    do { // get new ephemeral private key
+        sts = ippsGFpECPrivateKey(bnEphPrivate, pEC, ippsPRNGen, pRand);
+        CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECPrivateKey")
+        ippsCmpZero_BN(bnEphPrivate, &isZeroRes);
+        ippsCmp_BN(bnEphPrivate, bnRegPrivate, &isEquRes);
+    } while (isZeroRes == IS_ZERO || isEquRes == IPP_IS_EQ);
+
+    /* signature */
+    int ordWordSize = primeWordSize;
+    int sByteSize;
+    sts = ippsBigNumGetSize(ordWordSize, &sByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffS)
+    alloc_buf(sByteSize + IPPCP_DATA_ALIGNMENT, &buffS);
+    memset(buffS.buf, 0, sByteSize + IPPCP_DATA_ALIGNMENT);
+    IppsBigNumState* bnS = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffS.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippcp_init_set_bn(bnS, ordWordSize, ippBigNumPOS, (const Ipp32u *)data->msg.buf, ordWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    int rByteSize;
+    sts = ippsBigNumGetSize(ordWordSize, &rByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffR)
+    alloc_buf(rByteSize + IPPCP_DATA_ALIGNMENT, &buffR);
+    memset(buffR.buf, 0, rByteSize + IPPCP_DATA_ALIGNMENT);
+    IppsBigNumState* bnR = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffR.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippcp_init_set_bn(bnR, ordWordSize, ippBigNumPOS, (const Ipp32u *)data->msg.buf, ordWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    /* Tmp buffer */
+    int srcatchSize;
+    sts = ippsGFpECScratchBufferSize(2, pEC, &srcatchSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECScratchBufferSize")
+    BUFFER_INIT(buffScratch)
+    alloc_buf(srcatchSize + IPPCP_DATA_ALIGNMENT, &buffScratch);
+
+    /* RSA Signature Generation */
+    sts = ippsGFpECSignDSA(bnMsgDigest, bnRegPrivate, bnEphPrivate,
+                           bnR, bnS, pEC, buffScratch.buf);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECSignDSA")
+
+    int tmpSize;
+    /* Get S component */
+    ippsRef_BN(NULL, &tmpSize, NULL, bnS);
+    tmpSize = IPPCP_BITS2BYTES(tmpSize);
+    alloc_buf(primeByteSize, &data->S);
+    memset(data->S.buf, 0, primeByteSize);
+    BUFFER_INIT(buffSRevert);
+    alloc_buf(primeByteSize, &buffSRevert);
+    memset(buffSRevert.buf, 0, primeByteSize);
+
+    sts = ippsRef_BN(NULL, NULL, (Ipp32u**)&(buffSRevert.buf), bnS);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRef_BN")
+    dataReverse(data->S.buf, (const char *)buffSRevert.buf, primeByteSize);
+
+    /* Get R component */
+    sts = ippsRef_BN(NULL, &tmpSize, NULL, bnR);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRef_BN")
+    tmpSize = IPPCP_BITS2BYTES(tmpSize);
+    alloc_buf(primeByteSize, &data->R);
+    memset(data->R.buf, 0, primeByteSize);
+    BUFFER_INIT(buffRRevert);
+    alloc_buf(primeByteSize, &buffRRevert);
+    memset(buffRRevert.buf, 0, primeByteSize);
+    sts = ippsRef_BN(NULL, NULL, (Ipp32u**)&(buffRRevert.buf), bnR);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsRef_BN")
+    dataReverse(data->R.buf, (const char *)buffRRevert.buf, primeByteSize);
+
+out:
+    free_buf(&buffScratch);
+    free_buf(&buffR);
+    free_buf(&buffS);
+    free_buf(&buffEphKey);
+    free_buf(&buffMsgTmp);
+    free_buf(&buffMsg);
+    free_buf(&buffGFp);
+    free_buf(&buffGFpEC);
+
+    return ret;
+}
+
+static int ippcp_ecdsa_sigver(struct ecdsa_sigver_data *data, flags_t parsed_flags) {
+    int ret = 0;
+    (void)parsed_flags;
+    IppStatus sts = ippStsNoErr;
+
+    int primeBitSize = 0, primeWordSize = 0;
+    const IppsGFpMethod *pGFpMethod = NULL;
+    InitStdFunction_t initStdF      = NULL;
+    switch (data->cipher & ACVP_CURVEMASK) {
+		case ACVP_NISTP256:
+            primeBitSize = 256;
+            primeWordSize = 8;
+			pGFpMethod = ippsGFpMethod_p256r1();
+            initStdF = ippsGFpECInitStd256r1;
+			break;
+		case ACVP_NISTP384:
+            primeBitSize = 384;
+            primeWordSize = 12;
+			pGFpMethod = ippsGFpMethod_p384r1();
+            initStdF = ippsGFpECInitStd384r1;
+			break;
+		case ACVP_NISTP521:
+            primeBitSize = 521;
+            primeWordSize = 17;
+			pGFpMethod = ippsGFpMethod_p521r1();
+            initStdF = ippsGFpECInitStd521r1;
+			break;
+		default:
+			logger(LOGGER_ERR, "Unknown curve\n");
+	}
+
+    int ctx_size = 0;
+    sts = ippsGFpGetSize(primeBitSize, &ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpGetSize")
+    BUFFER_INIT(buffGFp)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &buffGFp);
+    IppsGFpState* pGF = (IppsGFpState*)(IPP_ALIGNED_PTR(buffGFp.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsGFpInitFixed(primeBitSize, pGFpMethod, pGF);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpInitFixed")
+
+    /* GFpEC context */
+    ctx_size = 0;
+    sts = ippsGFpECGetSize(pGF, &ctx_size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECGetSize")
+    BUFFER_INIT(buffGFpEC)
+    alloc_buf(ctx_size + IPPCP_DATA_ALIGNMENT, &buffGFpEC);
+    IppsGFpECState* pEC = (IppsGFpECState*)(IPP_ALIGNED_PTR(buffGFpEC.buf, IPPCP_DATA_ALIGNMENT));
+    sts = initStdF(pGF, pEC);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in initStdF")
+
+    /* message */
+    int msgByteSize = data->msg.len;
+    int msgWordSize = (msgByteSize + 3)/4;
+    int msgCtxByteSize;
+    sts = ippsBigNumGetSize(msgWordSize, &msgCtxByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffMsg)
+    alloc_buf(msgCtxByteSize + IPPCP_DATA_ALIGNMENT, &buffMsg);
+    IppsBigNumState* bnMsgDigest = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffMsg.buf, IPPCP_DATA_ALIGNMENT));
+
+    BUFFER_INIT(buffMsgTmp)
+    alloc_buf(msgByteSize, &buffMsgTmp);
+    dataReverse(buffMsgTmp.buf, (const char *)data->msg.buf, msgByteSize);
+    sts = ippcp_init_set_bn(bnMsgDigest, msgWordSize, ippBigNumPOS, (const Ipp32u *)buffMsgTmp.buf, msgWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    /* signature component S */
+    int ordWordSize = primeWordSize;
+    int sByteSize;
+    sts = ippsBigNumGetSize(ordWordSize, &sByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffS)
+    alloc_buf(sByteSize + IPPCP_DATA_ALIGNMENT, &buffS);
+    IppsBigNumState* bnS = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffS.buf, IPPCP_DATA_ALIGNMENT));
+    BUFFER_INIT(buffSRevert)
+    alloc_buf(data->S.len, &buffSRevert);
+    dataReverse(buffSRevert.buf, (const char *)data->S.buf, data->S.len);
+    sts = ippcp_init_set_bn(bnS, ordWordSize, ippBigNumPOS, (const Ipp32u *)buffSRevert.buf, ordWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    /* signature component R */
+    int rByteSize;
+    sts = ippsBigNumGetSize(ordWordSize, &rByteSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsBigNumGetSize")
+    BUFFER_INIT(buffR)
+    alloc_buf(rByteSize + IPPCP_DATA_ALIGNMENT, &buffR);
+    IppsBigNumState* bnR = (IppsBigNumState*)(IPP_ALIGNED_PTR(buffR.buf, IPPCP_DATA_ALIGNMENT));
+    BUFFER_INIT(buffRRevert)
+    alloc_buf(data->R.len, &buffRRevert);
+    dataReverse(buffRRevert.buf, (const char *)data->R.buf, data->R.len);
+    sts = ippcp_init_set_bn(bnR, ordWordSize, ippBigNumPOS, (const Ipp32u *)buffRRevert.buf, ordWordSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippcp_init_set_bn")
+
+    int size;
+    sts = ippsGFpElementGetSize(pGF, &size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpElementGetSize")
+    BUFFER_INIT(buffGFpElemX)
+    alloc_buf(size, &buffGFpElemX);
+    IppsGFpElement* pubGx = (IppsGFpElement*)buffGFpElemX.buf;
+    BUFFER_INIT(buffGxTmp)
+    alloc_buf(data->Qx.len, &buffGxTmp);
+    dataReverse(buffGxTmp.buf, (const char *)data->Qx.buf, data->Qx.len);
+    int len32 = (data->Qx.len + 3)/4;
+    sts = ippsGFpElementInit((const Ipp32u *)buffGxTmp.buf, len32, pubGx, pGF);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpElementInit")
+
+    sts = ippsGFpElementGetSize(pGF, &size);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpElementGetSize")
+    BUFFER_INIT(buffGFpElemY)
+    alloc_buf(size, &buffGFpElemY);
+    IppsGFpElement* pubGy = (IppsGFpElement*)buffGFpElemY.buf;
+    BUFFER_INIT(buffGyTmp)
+    alloc_buf(data->Qy.len, &buffGyTmp);
+    dataReverse(buffGyTmp.buf, (const char *)data->Qy.buf, data->Qy.len);
+    len32 = (data->Qy.len + 3)/4;
+    sts = ippsGFpElementInit((const Ipp32u *)buffGyTmp.buf, len32, pubGy, pGF);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpElementInit")
+
+    /* Init public key */
+    int pubKeyCtxSize;
+    sts = ippsGFpECPointGetSize(pEC, &pubKeyCtxSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECPointGetSize")
+    BUFFER_INIT(buffPubKey)
+    alloc_buf(pubKeyCtxSize + IPPCP_DATA_ALIGNMENT, &buffPubKey);
+    IppsGFpECPoint* regPublic = (IppsGFpECPoint*)(IPP_ALIGNED_PTR(buffPubKey.buf, IPPCP_DATA_ALIGNMENT));
+    sts = ippsGFpECPointInit(pubGx, pubGy, regPublic, pEC);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECPointInit")
+
+    /* Tmp  buffer */
+    int srcatchSize;
+    sts = ippsGFpECScratchBufferSize(2, pEC, &srcatchSize);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECScratchBufferSize")
+    BUFFER_INIT(buffScratch)
+    alloc_buf(srcatchSize + IPPCP_DATA_ALIGNMENT, &buffScratch);
+
+    /* RSA Signature Generation */
+    data->sigver_success = 1;
+    IppECResult verifRes;
+    sts = ippsGFpECVerifyDSA(bnMsgDigest, regPublic, bnR,
+                             bnS, &verifRes, pEC, buffScratch.buf);
+    CKNULL_LOG((sts == ippStsNoErr), sts, "Error in ippsGFpECVerifyDSA")
+
+    if(ippECValid != verifRes) {
+        data->sigver_success = 0;
+    }
+
+out:
+    free_buf(&buffGFp);
+    free_buf(&buffGFpEC);
+    free_buf(&buffMsg);
+    free_buf(&buffMsgTmp);
+    free_buf(&buffS);
+    free_buf(&buffSRevert);
+    free_buf(&buffR);
+    free_buf(&buffRRevert);
+    free_buf(&buffGFpElemX);
+    free_buf(&buffGxTmp);
+    free_buf(&buffGFpElemY);
+    free_buf(&buffGyTmp);
+    free_buf(&buffPubKey);
+    free_buf(&buffScratch);
+
+    return ret;
+}
+
+static struct ecdsa_backend ippcp_ecdsa =
+{
+	NULL,                 /* ecdsa_keygen_testing */
+	NULL,
+	NULL,                 /* ecdsa_pkvver */
+	ippcp_ecdsa_siggen,   /* ecdsa_siggen */
+	ippcp_ecdsa_sigver,   /* ecdsa_sigver */
+	ippcp_ecdsa_keygen_en,
+	ippcp_ecdsa_free_key,
+};
+
+ACVP_DEFINE_CONSTRUCTOR(ippcp_ecdsa_backend)
+static void ippcp_ecdsa_backend(void)
+{
+	register_ecdsa_impl(&ippcp_ecdsa);
+}

--- a/backends/backend_ippcrypto.c
+++ b/backends/backend_ippcrypto.c
@@ -848,7 +848,7 @@ out:
     free_buf(&buffN);
     free_buf(&buffE);
     free_buf(&pLocSignBuffer);
-    if(data->saltlen) {
+    if(salt) {
         free(salt);
     }
 

--- a/backends/backend_ippcrypto_common.h
+++ b/backends/backend_ippcrypto_common.h
@@ -1,0 +1,125 @@
+/*************************************************************************
+* Copyright (C) 2024 Intel Corporation
+*
+* Licensed under the Apache License,  Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* 	http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law  or agreed  to  in  writing,  software
+* distributed under  the License  is  distributed  on  an  "AS IS"  BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the  specific  language  governing  permissions  and
+* limitations under the License.
+*************************************************************************/
+
+#ifndef _IPPCRYPTO_COMMON_H
+#define _IPPCRYPTO_COMMON_H
+
+#include <strings.h>
+#include <ctype.h>
+
+#include <openssl/rand.h>
+
+/* Useful defines */
+
+#define IPPCP_DATA_ALIGNMENT  ((int)sizeof(void *))
+static __inline Ipp64s IPP_INT_PTR( const void* ptr )
+{
+    union {
+        void*   Ptr;
+        Ipp64s  Int;
+    } dd;
+    dd.Ptr = (void*)ptr;
+    return dd.Int;
+}
+#define IPP_ALIGN_TYPE(type, align)      ((align)/sizeof(type)-1)
+#define IPP_BYTES_TO_ALIGN(ptr, align)   ((~(IPP_INT_PTR(ptr)&((align)-1))+1)&((align)-1))
+#define IPP_ALIGNED_PTR(ptr, align)      (void*)( (unsigned char*)(ptr) + (IPP_BYTES_TO_ALIGN( ptr, align )) )
+
+#define IPPCP_BYTES2BITS(BITSIZE)   ((BITSIZE) * 8)
+#define IPPCP_BITS2BYTES(BYTESIZE)  (((BYTESIZE) + 7) >> 3)
+
+__attribute__((aligned(64))) static const Ipp8u seed0[]  = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                                                           "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                                                           "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                                                           "\x00\x00";
+
+/* Useful stuff functions */
+
+// Inverts order of the data to fit the expected by API data representation
+static void dataReverse(Ipp8u* pBuf, const char* str, int size) {
+    for(int i = 0; i < size; i++) {
+        pBuf[i] = str[size - i - 1];
+    }
+}
+
+// A helper function to set IppsBigNumState context
+static IppStatus ippcp_init_set_bn(IppsBigNumState *pbn, int max_word_len, IppsBigNumSGN sgn,
+                                   const Ipp32u *pdata, int data_word_len) {
+    IppStatus sts;
+    sts = ippsBigNumInit(max_word_len, pbn);
+    if (sts != ippStsNoErr)
+        return sts;
+
+    sts = ippsSet_BN(sgn, data_word_len, pdata, pbn);
+    return sts;
+}
+
+// A helper function to allocate IppsBigNumState context
+static IppsBigNumState* newBN(int numberWordSize, const Ipp32u* pData) {
+    int bnByteSize;
+    IppStatus sts = ippsBigNumGetSize(numberWordSize, &bnByteSize);
+    if (sts != ippStsNoErr) {
+        return NULL;
+    }
+
+    BUFFER_INIT(buff)
+    alloc_buf(bnByteSize+8, &buff);
+    IppsBigNumState* BN = (IppsBigNumState *)buff.buf;
+    sts = ippcp_init_set_bn(BN, numberWordSize,  ippBigNumPOS, pData,  numberWordSize);
+    if (sts != ippStsNoErr) {
+	    free_buf(&buff);
+        return NULL;
+    }
+
+    return BN;
+}
+
+// A helper function to generate random string
+static Ipp32u* rand32(Ipp32u* pX, int size) {
+   for (int n = 0; n < size; n++)
+      pX[n] = (rand() << 16) + rand();
+   return pX;
+}
+
+// A helper function to init new PRNG
+static IppsPRNGState* newPRNG(void)
+{
+    int ctxSize = 0;
+    IppsPRNGState* pRand = 0;
+    ippsPRNGGetSize(&ctxSize);
+    pRand = (IppsPRNGState*)(malloc(ctxSize));
+
+    int seedBitSize = 200;
+    int seedWordSize = 6;
+    Ipp32u dataSeed[25];
+    IppsBigNumState* seed = newBN(seedWordSize, rand32(dataSeed, IPPCP_BITS2BYTES(seedBitSize)));
+
+    IppStatus sts = ippsPRNGInit(seedBitSize, pRand);
+    if (sts != ippStsNoErr) {
+	    free_buf((struct buffer*)seed);
+        return NULL;
+    }
+    //sts = ippsPRNGSetSeed(seed, pRand);
+    if (sts != ippStsNoErr) {
+        free_buf((struct buffer*)seed);
+        return NULL;
+    }
+
+    return pRand;
+}
+
+
+#endif //_IPPCRYPTO_COMMON_H


### PR DESCRIPTION
Intel® Integrated Performance Primitives Cryptography is an Intel® project consistent from two cryptographic libraries (ippcp and crypto_mb) which are highly optimized for various Intel® CPUs.
Product related links: [open-source repo](https://github.com/intel/ipp-crypto), [IPPCP Developer Guide and Reference](https://www.intel.com/content/www/us/en/docs/ipp-crypto/developer-guide-reference/current/overview.html).
Currently supported request configurations:
[IPPCPcommonRequest.json](https://github.com/smuellerDD/acvpparser/files/14886624/IPPCPcommonRequest.json)
[CRYPTOMBcommonRequest.json](https://github.com/smuellerDD/acvpparser/files/14886634/CRYPTOMBcommonRequest.json)
