### PR TITLE
Add improvements to the openssl backends

### DIFF
--- a/backends/backend_openssl.c
+++ b/backends/backend_openssl.c
@@ -1434,6 +1434,9 @@ static int openssl_kdf_ssh(struct kdf_ssh_data *data, flags_t parsed_flags)
 	case ACVP_SHA1:
 		maclen = 20;
 		break;
+	case ACVP_SHA224:
+		maclen = 28;
+		break;
 	case ACVP_SHA256:
 		maclen = 32;
 		break;

--- a/backends/backend_openssl3.c
+++ b/backends/backend_openssl3.c
@@ -2815,7 +2815,8 @@ static int openssl_rsa_keygen_internal(uint32_t modulus, struct buffer *ebuf,
 	CKNULL(e, -ENOMEM);
 
 	bld = OSSL_PARAM_BLD_new();
-	if (xpbuf && xp1buf && xp2buf) {
+	if (xpbuf && xp1buf && xp2buf &&
+	    xpbuf->buf && xp1buf->buf && xp2buf->buf) {
 		CKNULL_LOG(xpbuf->len, -EFAULT,
 			   "xP must be provided by ACVP server\n");
 		CKNULL_LOG(xp1buf->len, -EFAULT,
@@ -2835,7 +2836,8 @@ static int openssl_rsa_keygen_internal(uint32_t modulus, struct buffer *ebuf,
 		OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_TEST_XP1, xp1);
 		OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_RSA_TEST_XP2, xp2);
 	}
-	if (xqbuf && xq1buf && xq2buf) {
+	if (xqbuf && xq1buf && xq2buf &&
+	    xqbuf->buf && xq1buf->buf && xq2buf->buf) {
 		CKNULL_LOG(xqbuf->len, -EFAULT,
 			   "xQ must be provided by ACVP server\n");
 		CKNULL_LOG(xq1buf->len, -EFAULT,


### PR DESCRIPTION
Add improvements to the openssl backends:
* Add support for SHA224 algorithm in openssl SSH KDF backend (recently similar change has been added to openssl3 backend, so it has been removed from this patch after rebase);
* Update AES-XTS tweak value handling in common openssl backend;
* Allow RSA keygen Generated Data Tests in openssl3 backend.

[AES_XTS-response.json](https://github.com/user-attachments/files/15986620/AES_XTS-response.json)
[AES_XTS-request.json](https://github.com/user-attachments/files/15986622/AES_XTS-request.json)
[RSA_keygen-request.json](https://github.com/user-attachments/files/15986623/RSA_keygen-request.json)
