### PR TITLE
Dpev/ecdsa fix

### DIFF
--- a/parser/parser_ecdsa.c
+++ b/parser/parser_ecdsa.c
@@ -413,9 +413,9 @@ static int ecdsa_tester(struct json_object *in, struct json_object *out,
 	struct buffer ecdsa_revision = { .buf = (unsigned char *)"1.0",
 					 .len = 6 };
 	const struct json_entry gen_ecdsa_testgroup_result_entries[] = {
-		{"algorithm",	{.data.buf = &ecdsa_algo,  WRITER_STRING_NOFREE},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN },
-		{"mode",	{.data.buf = &ecdsa_sigver_mode, WRITER_STRING_NOFREE},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN },
-		{"revision",	{.data.buf = &ecdsa_revision, WRITER_STRING_NOFREE},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN },
+		{"algorithm",	{.data.buf = &ecdsa_algo,  WRITER_STRING_NOFREE},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN | FLAG_OP_ASYM_TYPE_SIGVER },
+		{"mode",	{.data.buf = &ecdsa_sigver_mode, WRITER_STRING_NOFREE},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN | FLAG_OP_ASYM_TYPE_SIGVER },
+		{"revision",	{.data.buf = &ecdsa_revision, WRITER_STRING_NOFREE},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN | FLAG_OP_ASYM_TYPE_SIGVER },
 	};
 	/*
 	 * The NULL for the function callbacks implies that the qx and qy
@@ -425,6 +425,7 @@ static int ecdsa_tester(struct json_object *in, struct json_object *out,
 
 	const struct json_entry gen_ecdsa_testanchor_entries[] = {
 		{"testGroups",	{.data.array = &gen_ecdsa_siggen_testgroup, PARSER_ARRAY},	FLAG_OP_ASYM_TYPE_SIGGEN},
+		{"testGroups",	{.data.array = &ecdsa_sigver_testgroup, PARSER_ARRAY},	FLAG_OP_ASYM_TYPE_SIGVER},
 	};
 	const struct json_array gen_ecdsa_testanchor = SET_ARRAY(gen_ecdsa_testanchor_entries, &gen_ecdsa_testgroup_result);
 

--- a/parser/parser_ecdsa.c
+++ b/parser/parser_ecdsa.c
@@ -372,10 +372,6 @@ static int ecdsa_tester(struct json_object *in, struct json_object *out,
 	const struct json_entry gen_ecdsa_siggen_testresult_entries[] = {
 		{"r",		{.data.buf = &ecdsa_siggen_vector.R, WRITER_BIN},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN },
 		{"s",		{.data.buf = &ecdsa_siggen_vector.S, WRITER_BIN},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN },
-		{"qx",		{.data.buf = &ecdsa_siggen_vector.Qx, WRITER_BIN},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN},
-		{"qy",		{.data.buf = &ecdsa_siggen_vector.Qy, WRITER_BIN},	FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN},
-		{"message",	{.data.buf = &ecdsa_siggen_vector.msg, WRITER_BIN },
-			         FLAG_OP_AFT | FLAG_OP_ASYM_TYPE_SIGGEN},
 	};
 	const struct json_testresult gen_ecdsa_siggen_testresult = SET_ARRAY(gen_ecdsa_siggen_testresult_entries, &ecdsa_siggen_callbacks);
 


### PR DESCRIPTION
Some issues with current (June 2024) acvp vectors. For SigGen qx/qy were being output per test, and for SigVer the flag was missing on the declarations preventing the test callback from executing.

Thanks for providing this very valuable framework to the public! :)