### PR TITLE
Support ACVP_CBC case in kcapi_lrng backend

### DIFF
--- a/backends/backend_kcapi_lrng.c
+++ b/backends/backend_kcapi_lrng.c
@@ -162,6 +162,9 @@ static int kcapi_rawciphername(uint64_t cipher, char **cipherstring)
 	case ACVP_ECB:
 		sprintf(outstr, "ecb(aes)");
 		break;
+	case ACVP_CBC:
+		sprintf(outstr, "cbc(aes)");
+		break;
 
 	case ACVP_HMACSHA1:
 		sprintf(outstr, "hmac(sha1)");
@@ -213,6 +216,9 @@ static int kcapi_ciphername(uint64_t cipher, char **cipherstring)
 	switch (cipher) {
 	case ACVP_ECB:
 		envstr = secure_getenv("KCAPI_ECB_AES");
+		break;
+	case ACVP_CBC:
+		envstr = secure_getenv("KCAPI_CBC_AES");
 		break;
 
 	case ACVP_HMACSHA1:


### PR DESCRIPTION
Prior to this adjustment, I encountered an error message indicating that...
```
ACVPParser (08:03:14) Error [backends/backend_kcapi_lrng.c:kcapi_ciphername:251]: Unknown cipher
```
But the kcapi_lrng backend can handle this test case if we incorporate support for it.
```
[PASSED] compare ACVP-AES-CBC-1.0/expected-response.json with ACVP-AES-CBC-1.0/testvector-response.json
```