### PR TITLE
LMS algorithm was added and small changes were made across backends specific for Intel Cryptography Primitives library

### DIFF
--- a/backends.mk
+++ b/backends.mk
@@ -302,14 +302,14 @@ ifeq (ippcrypto,$(firstword $(MAKECMDGOALS)))
 	ifeq ($(uname -m),x86_64)
 		CFLAGS += -mavx2 -mbmi2 -mpopcnt -g
 	endif
-	CFLAGS += -Wno-uninitialized
+	CFLAGS += -Wno-uninitialized -DIPPCP_PREVIEW_LMS
 
 	# Static link for lnx
 	ifeq ($(UNAME_S),Linux)
 		LDFLAGS += $(IPPCRYPTOROOT)/lib/libippcp.a
 		LIBRARIES += crypto ssl
 	else
-		LDFLAGS += -L $(IPPCRYPTOROOT)/lib/
+		LDFLAGS += -L $(IPPCRYPTOROOT)/lib/ -L $(OPENSSL_ROOT_DIR)/lib/
 		LIBRARIES += crypto ssl ippcp
 	endif
 	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib64/
@@ -333,7 +333,7 @@ ifeq (cryptomb,$(firstword $(MAKECMDGOALS)))
 		LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a $(IPPCRYPTOROOT)/lib/libippcp.a
 		LIBRARIES += crypto ssl
 	else
-		LDFLAGS += -L $(IPPCRYPTOROOT)/lib/
+		LDFLAGS += -L $(IPPCRYPTOROOT)/lib/ -L $(OPENSSL_ROOT_DIR)/lib/
 		LIBRARIES += crypto ssl ippcp crypto_mb
 	endif
 
@@ -357,11 +357,11 @@ ifeq (cryptombssl,$(firstword $(MAKECMDGOALS)))
 		LDFLAGS += $(IPPCRYPTOROOT)/lib/libcrypto_mb.a $(IPPCRYPTOROOT)/lib/libippcp.a
 		LIBRARIES += crypto ssl
 	else
-	    LDFLAGS += -L $(IPPCRYPTOROOT)/lib/
+	    LDFLAGS += -L $(IPPCRYPTOROOT)/lib/ -L $(OPENSSL_ROOT_DIR)/lib/
 		LIBRARIES += crypto ssl ippcp crypto_mb
 	endif
 
-	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib/ -L $(OPENSSL_ROOT_DIR)/bin/
+	LDFLAGS += -L $(OPENSSL_ROOT_DIR)/lib64/ -L $(OPENSSL_ROOT_DIR)/bin/
 	LD_LIBRARY_PATH += $(OPENSSL_ROOT_DIR)/lib64/
 endif
 

--- a/backends/backend_cryptomb_common.h
+++ b/backends/backend_cryptomb_common.h
@@ -379,7 +379,7 @@ __attribute__((aligned(64))) static const int8u pSeed[]  = "\x00\x00\x00\x00\x00
                                                            "\x00\x00";
 
 /* XOR block */
-__INLINE void XorBlock(const void* pSrc1, const void* pSrc2, void* pDst, int len)
+static void XorBlock(const void* pSrc1, const void* pSrc2, void* pDst, int len)
 {
    const Ipp8u* p1 = (const Ipp8u*)pSrc1;
    const Ipp8u* p2 = (const Ipp8u*)pSrc2;

--- a/backends/backend_ippcrypto_common.h
+++ b/backends/backend_ippcrypto_common.h
@@ -25,7 +25,7 @@
 /* Useful defines */
 
 #define IPPCP_DATA_ALIGNMENT  ((int)sizeof(void *))
-static __inline Ipp64s IPP_INT_PTR( const void* ptr )
+static Ipp64s IPP_INT_PTR( const void* ptr )
 {
     union {
         void*   Ptr;


### PR DESCRIPTION
This PR introduces the updates for backends specific for Intel Cryptography Primitives library.

**Details of the changes:**
* The backend for LMS algorithm was added;
* The usage of the deprecated in the library RNG was removed;
* Changed linking command due to specific OpenSSL layout on Windows;
* Corrected cryptomb backends because FIPS CAVP vectors representation was changed (the hash need to be calculated by testing harness);