### PR TITLE
backend_openssl3 support to use default provider

### DIFF
--- a/backends/backend_openssl3.c
+++ b/backends/backend_openssl3.c
@@ -23,12 +23,17 @@
 #include "backend_openssl_common.h"
 #include <openssl/provider.h>
 
+// The fips module is loaded by default.  To use the default provider,
+// build with CFLAGS+="-DOPENSSL3_BACKEND_USE_DEFAULT_PROVIDER".
+#ifndef OPENSSL3_BACKEND_USE_DEFAULT_PROVIDER
 OSSL_PROVIDER *fips;
 OSSL_PROVIDER *base;
+#endif
 
 ACVP_DEFINE_CONSTRUCTOR(openssl_backend_init)
 static void openssl_backend_init(void)
 {
+#ifndef OPENSSL3_BACKEND_USE_DEFAULT_PROVIDER
 	/* Explicitly load the FIPS provider as per fips_module(7) */
 	fips = OSSL_PROVIDER_load(NULL, "fips");
 	if (fips == NULL) {
@@ -46,14 +51,17 @@ static void openssl_backend_init(void)
 		printf("Failed to enable FIPS mode\n");
 		exit(-EFAULT);
 	}
+#endif
 }
 
 ACVP_DEFINE_DESTRUCTOR(openssl_backend_fini)
 static void openssl_backend_fini(void)
 {
+#ifndef OPENSSL3_BACKEND_USE_DEFAULT_PROVIDER
 	#pragma message "Deliberate memleak required for OpenSSL 3 - OpenSSL cleans itself using atexit"
 	//OSSL_PROVIDER_unload(base);
 	//OSSL_PROVIDER_unload(fips);
+#endif
 }
 
 /************************************************


### PR DESCRIPTION
This adds support for the openssl3 backend to use the default provider.

Why is this needed?
The openssl3 backend normally loads the fips provider module.  However, using fips is not mandatory and the tool can be used with the default algorithm provider.  In this case, it is inappropriate to load the fips module (if it even exists on the system) and to enable fips mode.

Building the tool with the new preprocessor symbol `OPENSSL3_BACKEND_USE_DEFAULT_PROVIDER` defined avoids using fips mode. To use this, build with `CFLAGS` containing `"-DOPENSSL3_BACKEND_USE_DEFAULT_PROVIDER"`.  The default is to use fips mode.

Tested:
Builds when the new symbol is not defined.
Builds with the new symbol defined, does not load the fips module, and succesfully runs the tests.