### PR TITLE
Fixed errors and warnings appearing during the build of `ippcrypto`, `cryptomb` and `cryptombssl` targets.

### DIFF
--- a/backends/backend_crypto_common.h
+++ b/backends/backend_crypto_common.h
@@ -1,0 +1,99 @@
+/*************************************************************************
+* Copyright (C) 2024 Intel Corporation
+*
+* Licensed under the Apache License,  Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* 	http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law  or agreed  to  in  writing,  software
+* distributed under  the License  is  distributed  on  an  "AS IS"  BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the  specific  language  governing  permissions  and
+* limitations under the License.
+*************************************************************************/
+
+#ifndef _BACKEND_CRYPTO_COMMON_H
+#define _BACKEND_CRYPTO_COMMON_H
+
+#ifdef DETERMINISTIC_KEY_GEN
+#ifndef OPENSSL_IS_BORINGSSL
+static int stdlib_rand_seed(const void* buf, int num)
+{
+    (void)num;
+    srand(*((unsigned int*)buf));
+    return 1;
+}
+
+static int stdlib_rand_bytes(unsigned char* buf, int num)
+{
+    for (int index = 0; index < num; ++index) {
+        buf[index] = rand() % 256;
+    }
+    return 1;
+}
+#else
+static void stdlib_rand_seed(const void* buf, int num) { (void)num; srand(*((unsigned int*)buf)); }
+
+static int stdlib_rand_bytes(uint8_t* buf, size_t num)
+{
+    for (int index = 0; index < num; ++index) {
+        buf[index] = rand() % 256;
+    }
+    return 1;
+}
+#endif
+
+// Suppress deprecation warnings for RAND_METHOD usage in OpenSSL 3.x
+#if OPENSSL_VERSION_MAJOR >= 3
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+RAND_METHOD stdlib_rand_meth = {
+    stdlib_rand_seed, stdlib_rand_bytes, NULL, NULL, stdlib_rand_bytes, NULL
+};
+#if OPENSSL_VERSION_MAJOR >= 3
+#pragma GCC diagnostic pop
+#endif
+
+// Global variable to store the original RAND method
+static const RAND_METHOD* current_ossl_rnd = NULL;
+
+static void set_drng_to_gen_rep_seq(Ipp32u seed)
+{
+    // Suppress deprecation warnings for OpenSSL 3.x
+#if OPENSSL_VERSION_MAJOR >= 3
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    // Store original RNG method for restoration
+    current_ossl_rnd = RAND_get_rand_method();
+    // Set deterministic RNG for generation
+    RAND_set_rand_method(&stdlib_rand_meth);
+
+    RAND_seed(&seed, sizeof(Ipp32u));
+#if OPENSSL_VERSION_MAJOR >= 3
+#pragma GCC diagnostic pop
+#endif
+}
+
+static void restore_original_rng()
+{
+#if OPENSSL_VERSION_MAJOR >= 3
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    if (current_ossl_rnd) {
+        // Restore original RNG method
+        RAND_set_rand_method(current_ossl_rnd);
+        current_ossl_rnd = NULL;
+    }
+#if OPENSSL_VERSION_MAJOR >= 3
+#pragma GCC diagnostic pop
+#endif
+}
+#endif
+
+#endif //_BACKEND_CRYPTO_COMMON_H

--- a/backends/backend_cryptomb.c
+++ b/backends/backend_cryptomb.c
@@ -967,7 +967,6 @@ static void cryptomb_kts_ifc_backend(void)
  * RSA priv exponent testing - rsa decrypt primitive
  ****************************************************/
 static int cryptomb_rsa_keygen_en(struct buffer *ebuf, uint32_t modulus, void **privkey, struct buffer *nbuf) {
-    static int key_counter = 0;
     int ret = 0;
 
 	BIGNUM *egen = BN_new();
@@ -981,6 +980,8 @@ static int cryptomb_rsa_keygen_en(struct buffer *ebuf, uint32_t modulus, void **
     int rsaBitsize = modulus;
 
 #ifdef DETERMINISTIC_KEY_GEN
+    // A counter to generate different key for each call
+    static int key_counter = 0;
     // Generate different key for each call
     set_drng_to_gen_rep_seq(1000 + key_counter++);
 #endif

--- a/backends/backend_cryptomb_common.h
+++ b/backends/backend_cryptomb_common.h
@@ -37,6 +37,7 @@
 #include <ippcp.h>
 
 #include "backend_common.h"
+#include "backend_crypto_common.h"
 
 #define NUM_OF_DIGS(bitsize, digsize)   (((bitsize) + (digsize)-1)/(digsize))
 

--- a/backends/backend_cryptomb_common.h
+++ b/backends/backend_cryptomb_common.h
@@ -37,7 +37,6 @@
 #include <ippcp.h>
 
 #include "backend_common.h"
-#include "backend_crypto_common.h"
 
 #define NUM_OF_DIGS(bitsize, digsize)   (((bitsize) + (digsize)-1)/(digsize))
 

--- a/backends/backend_cryptombssl.c
+++ b/backends/backend_cryptombssl.c
@@ -668,7 +668,6 @@ static void cryptomb_kts_ifc_backend(void)
  ****************************************************/
 static int cryptombssl_rsa_keygen_en(struct buffer *ebuf, uint32_t modulus, void **privkey, struct buffer *nbuf)
 {
-    static int key_counter = 0;
     int ret = 0;
 
 	BIGNUM *egen = BN_new();
@@ -682,6 +681,8 @@ static int cryptombssl_rsa_keygen_en(struct buffer *ebuf, uint32_t modulus, void
     int rsaBitsize = modulus;
 
 #ifdef DETERMINISTIC_KEY_GEN
+    // A counter to generate different key for each call
+    static int key_counter = 0;
     // Generate different key for each call
     set_drng_to_gen_rep_seq(1000 + key_counter++);
 #endif

--- a/backends/backend_ippcrypto.c
+++ b/backends/backend_ippcrypto.c
@@ -17,7 +17,6 @@
 #include "ippcp.h"
 #include "backend_common.h"
 #include "backend_ippcrypto_common.h"
-#include "backend_crypto_common.h"
 
 /************************************************************************************************
  * Symmetric cipher interface functions - AES-CBC, AES-CBC_CS1/2/3, AES-CTR, AES-OFB, AES_OFB128
@@ -1886,8 +1885,8 @@ static int ippcp_lms_sigver(struct lms_sigver_data *data, flags_t parsed_flags)
 
     /* Allocate memory for the scratch buffer */
     int buffSize;
-    status = ippsLMSBufferGetSize(&buffSize, msgLen, lmsAlgType);
-    CKNULL_LOG((status == ippStsNoErr), status, "Error in ippsLMSBufferGetSize")
+    status = ippsLMSVerifyBufferGetSize(&buffSize, msgLen, lmsAlgType);
+    CKNULL_LOG((status == ippStsNoErr), status, "Error in ippsLMSVerifyBufferGetSize")
     pScratchBuffer = malloc(buffSize);
 
     /* Parse public key vector */

--- a/backends/backend_ippcrypto.c
+++ b/backends/backend_ippcrypto.c
@@ -17,6 +17,7 @@
 #include "ippcp.h"
 #include "backend_common.h"
 #include "backend_ippcrypto_common.h"
+#include "backend_crypto_common.h"
 
 /************************************************************************************************
  * Symmetric cipher interface functions - AES-CBC, AES-CBC_CS1/2/3, AES-CTR, AES-OFB, AES_OFB128


### PR DESCRIPTION
* Added `backend_crypto_common.h` header.
* Replaced call `ippsLMSBufferGetSize()` with `ippsLMSVerifyBufferGetSize()`, as it was deprecated and will be removed in one of the upcoming major releases.
* key_counter is now used only under `DETERMINISTIC_KEY_GEN` build configuration.