### PR TITLE
openssl3: use canonical digest names for HMAC

### DIFF
--- a/backends/backend_openssl3.c
+++ b/backends/backend_openssl3.c
@@ -511,15 +511,19 @@ out:
 static int openssl_hmac_generate(struct hmac_data *data)
 {
 	const EVP_MD *md = NULL;
+	const char *mdname;
 	int ret = 0;
 
 	logger_binary(LOGGER_DEBUG, data->msg.buf, data->msg.len, "msg");
 	logger_binary(LOGGER_DEBUG, data->key.buf, data->key.len, "key");
 
 	CKINT(openssl_md_convert(data->cipher, &md));
+	mdname = OBJ_nid2sn(EVP_MD_get_type(md));
+	if (!mdname)
+		mdname = EVP_MD_name(md);
 
 	if (openssl_mac_generate_helper(data, "HMAC", OSSL_MAC_PARAM_DIGEST,
-		(char *)EVP_MD_name(md)))
+		(char *)mdname))
 	{
 		ret = -EFAULT;
 		goto out;


### PR DESCRIPTION
## Summary

Improve OpenSSL 3.5 provider compatibility for the OpenSSL 3 backend's HMAC path.

`openssl_hmac_generate()` currently passes `EVP_MD_name(md)` as the `OSSL_MAC_PARAM_DIGEST` value. With OpenSSL 3.5 provider-backed digest handling, that name can be provider-facing and may not be accepted by `EVP_MAC_CTX_set_params()` as the HMAC digest parameter.

This resolves the digest name through `OBJ_nid2sn(EVP_MD_get_type(md))` first, while keeping `EVP_MD_name(md)` as a fallback.

## Validation

- Built `make openssl` against a local OpenSSL 3.5 install.
- Verified an HMAC-SHA2-256 ACVP-style request that previously failed at `EVP_MAC_CTX_set_params()` now produces the expected MAC.
